### PR TITLE
Refactor config into nested structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gradient Garden
 
-Gradient Garden is a research playground for model training, evaluation, and experimentation across architectures, benchmarks, and recipes.
+Gradient Garden is a research platform for model training, evaluation, and experimentation across architectures, benchmarks, and recipes.
 
 The project began with a decoder-only transformer baseline and has evolved into a broader codebase for training, evaluation, and experimentation across modern machine learning models, distributed training workflows, and post-training methods.
 
@@ -89,7 +89,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `lr_schedulers.py` Stores learning rate schedulers. At the moment, it includes a cosine scheduler.
 - `model.py` Current main model implementation.
 - `prepare_datasets.py` Entry point for data downloading and preparation.
-- `test_prompts.json` JSON with the list of input prompts to try during training. The expected keys in the JSON (as provided in the file) are "pretrain", "instruct", "dpo".
+- `test_prompts.json` JSON with the list of input prompts to try during training. The expected keys in the JSON (as provided in the file) are "pretraining", "instruct", "dpo".
 - `tokenizer.py` Provides the tokenizer abstraction used by the project and supports two backends:
   - `TikTokenizer`: loads tiktoken BPE weights from a local file path and configures the special tokens used by the project.
   - `HFTokenizer`: loads a tokenizer from Hugging Face via `AutoTokenizer.from_pretrained(...)` and aligns the required special tokens (`bos`, `eos`, headers, `eot`, `pad`).
@@ -130,11 +130,11 @@ The file `config.py` defines all the environment variables required.
 `train.py` accepts some flags that are useful to load a checkpoint or override some properties:
 
 ```bash
-  --pretrain_checkpoint <file>   # Resume pre-training run
-  --instruct_checkpoint <file>   # Resume SFT run
-  --dpo_checkpoint <file>        # Resume DPO run
-  --reset-optimizers             # Ignore stored optimizer(s) state
-  --start-step <N>               # Override internal step counter
+  --pretraining_checkpoint <file>   # Resume pretraining run
+  --instruct_checkpoint <file>      # Resume SFT run
+  --dpo_checkpoint <file>           # Resume DPO run
+  --reset-optimizers                # Ignore stored optimizer(s) state
+  --start-step <N>                  # Override internal step counter
 ```
 **NOTE:** The checkpoint paths need to be set in the `.env` file. See `config.py` for details.
 
@@ -161,7 +161,7 @@ The file `config.py` defines all the environment variables required.
     torchrun \
       --standalone \
       --nproc_per_node <NUMBER_OF_GPUs> \
-      train.py --pretrain_checkpoint <CHECKPOINT_FILE_NAME>
+      train.py --pretraining_checkpoint <CHECKPOINT_FILE_NAME>
     ```
     - NOTE: When loading an instruct checkpoint, use `--instruct_checkpoint` instead. This will also load the optimizer(s) state and resume from the stored step. You can reset the optimizer(s) with the flag `--reset-optimizers` and set the start step with the flag `--start-step`. E.g.: `--start-step 10`
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ The file `config.py` defines all the environment variables required.
 `train.py` accepts some flags that are useful to load a checkpoint or override some properties:
 
 ```bash
-  --pretraining_checkpoint <file>   # Resume pretraining run
-  --instruct_checkpoint <file>      # Resume SFT run
-  --dpo_checkpoint <file>           # Resume DPO run
+  --pretraining-checkpoint <file>   # Resume pretraining run
+  --instruct-checkpoint <file>      # Resume SFT run
+  --dpo-checkpoint <file>           # Resume DPO run
   --reset-optimizers                # Ignore stored optimizer(s) state
   --start-step <N>                  # Override internal step counter
 ```
@@ -161,7 +161,7 @@ The file `config.py` defines all the environment variables required.
     torchrun \
       --standalone \
       --nproc_per_node <NUMBER_OF_GPUs> \
-      train.py --pretraining_checkpoint <CHECKPOINT_FILE_NAME>
+      train.py --pretraining-checkpoint <CHECKPOINT_FILE_NAME>
     ```
     - NOTE: When loading an instruct checkpoint, use `--instruct_checkpoint` instead. This will also load the optimizer(s) state and resume from the stored step. You can reset the optimizer(s) with the flag `--reset-optimizers` and set the start step with the flag `--start-step`. E.g.: `--start-step 10`
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Gradient Garden
 
-Gradient Garden is a research platform for model training, evaluation, and experimentation across architectures, benchmarks, and recipes.
+Gradient Garden is a research platform for model training, evaluation, and experimentation across architectures, benchmarks, and multi stage training workflows.
 
 The project began with a decoder-only transformer baseline and has evolved into a broader codebase for training, evaluation, and experimentation across modern machine learning models, distributed training workflows, and post-training methods.
 
 ## Current focus
 - Distributed training
 - Multi-stage model training and post-training workflows
-- Research and experimentation across architectures, benchmarks, and training recipes
+- Research and experimentation across architectures, benchmarks, and training configurations
 
 ## Current capabilities
 
@@ -71,12 +71,14 @@ The project began with a decoder-only transformer baseline and has evolved into 
     - HellaSwag
     - WinoGrande
     - ARC-Challenge
-- `examples/` Templates for the `.env` config and dataset mix.
+- `examples/` Templates for the `.env` secrets file and dataset mix. This will be replaced by recipe directories in a future PR.
 - `metrics/` Utilities for metric aggregation.
 - `tasks/` Groups the training tasks.
 - `tests/` Groups tests for different components.
 - `checkpoints.py` Logic to handle checkpointing.
-- `config.py` Defines the main config and environment variables that are to be extracted from `.env`.
+- `config.py` Defines the nested `GlobalConfig` used by the trainer, dataset preparation, evaluation, checkpointing, and runtime setup.
+  - Most experiment settings currently live as defaults in `config.py`.
+  - `.env` is only used for third party secrets and local cache settings: `WANDB_API_KEY`, `HF_TOKEN`, and `HF_HOME`.
 - `dataloaders.py` Dataloader logic for sampling and distributing data.
 - `ddp_utils.py` Contains the main logic to set up the PyTorch DDP (Distributed Data Parallel) and FSDP2 (Fully Sharded Data Parallel).
   - PyTorch DDP [here](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html)
@@ -85,7 +87,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `generate.py` Logic for sampling and text generation.
 - `kv_cache.py` KV cache implementation.
 - `logger.py` Simple reusable logger.
-- `lora.py` LoRA module that handles the model modification. Rank, alpha, dropout and target modules can be configured in the `.env` file.
+- `lora.py` LoRA module that handles the model modification. Rank, alpha, dropout and target modules can be configured accordingly.
 - `lr_schedulers.py` Stores learning rate schedulers. At the moment, it includes a cosine scheduler.
 - `model.py` Current main model implementation.
 - `prepare_datasets.py` Entry point for data downloading and preparation.
@@ -93,7 +95,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `tokenizer.py` Provides the tokenizer abstraction used by the project and supports two backends:
   - `TikTokenizer`: loads tiktoken BPE weights from a local file path and configures the special tokens used by the project.
   - `HFTokenizer`: loads a tokenizer from Hugging Face via `AutoTokenizer.from_pretrained(...)` and aligns the required special tokens (`bos`, `eos`, headers, `eot`, `pad`).
-  - `init_tokenizer(...)` selects the backend based on configuration (`HUGGINGFACE_TOKENIZER`).
+  - `init_tokenizer(...)` selects the backend based on `config.tokenizer.huggingface_tokenizer`.
 - `train.py` Entry point for training runs.
 - `wandb_utils.py` A wrapper for Weights & Biases.
   - Weights & Biases [here](https://wandb.ai/site/)
@@ -110,7 +112,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
     - Pretraining: `python prepare_datasets.py --pretraining`
     - Instruct: `python prepare_datasets.py --instruct`
     - DPO: `python prepare_datasets.py --dpo`
-  - **NOTE**: All the target paths can be modified in the `.env` file. (Check config.py for more details.)
+  - **NOTE**: Dataset paths are configured in `config.py` under `GlobalConfig.paths.datasets` and `GlobalConfig.paths.evals`.
   - The training dataset preparation commands also support a custom mix file by passing `--mix-file <file_path>`. Check `examples/pretraining_data_mix.example.json` for an example. Local custom mix files should use the `.local.json` suffix, for example `pretraining_debug.local.json`, so they are ignored by Git. If no `--mix-file` is provided, the built-in default mix for that stage is used.
     - The default mix can be found in `datasets_preparation/default_mixes.py`
   
@@ -119,12 +121,35 @@ The project began with a decoder-only transformer baseline and has evolved into 
 
 - **NOTE:** For some scenarios you might need to also pass your Hugging Face API token `HF_TOKEN`. E.g.: If performing knowledge distillation and the teacher model requires access permissions.
 
-## Configuring and training:
-The project expects a `.env` file at the repository root. Check `examples/.env.example` and use it as a template.
-The file `config.py` defines all the environment variables required.
-- Modify it according to your experiment needs (e.g., model architecture, hyperparameters, Weights & Biases settings, checkpointing, etc.).
+## Configuring and training
 
-**NOTE:** Values in `.env` override the corresponding defaults defined in `config.py`.
+Configuration is currently defined through the nested `GlobalConfig` object in `config.py`.
+
+The main sections are:
+- `runtime`: device, precision, FSDP, torch compile, CPU workers
+- `model`: transformer architecture and optional MoE settings
+- `training`: stage, seed, total batch size, max steps, early stopping
+- `optimizers`: AdamW and optional Muon configuration
+- `paths`: dataset, evaluation, checkpoint, and prompt paths
+- `validation`: validation frequency and number of validation steps
+- `evals`: HellaSwag, WinoGrande, and ARC-Challenge settings
+- `generation`: text generation frequency and max generation length
+- `checkpointing`: checkpoint save frequency and retention
+- `tokenizer`: tokenizer backend and checkpoint path
+- `lora`: optional LoRA configs
+- `distillation`: optional teacher model distillation settings
+- `dpo`: DPO configuration
+- `wandb`: W&B logging settings
+- `torch_profiler`: profiler settings
+
+`.env` is no longer used as the experiment configuration file. It is only used for secrets and local cache settings:
+```
+WANDB_API_KEY=''
+HF_TOKEN=''
+HF_HOME='./cache'
+```
+
+**NOTE:** Experiment recipe directories will be introduced in a future update.
 
 ### Common flags
 `train.py` accepts some flags that are useful to load a checkpoint or override some properties:
@@ -136,7 +161,7 @@ The file `config.py` defines all the environment variables required.
   --reset-optimizers                # Ignore stored optimizer(s) state
   --start-step <N>                  # Override internal step counter
 ```
-**NOTE:** The checkpoint paths need to be set in the `.env` file. See `config.py` for details.
+**NOTE:** The checkpoint paths are configured in `config.py` under `GlobalConfig.paths.checkpoints`.
 
 ### Running the Training
 - To train on **single-GPU**, run:
@@ -163,7 +188,7 @@ The file `config.py` defines all the environment variables required.
       --nproc_per_node <NUMBER_OF_GPUs> \
       train.py --pretraining-checkpoint <CHECKPOINT_FILE_NAME>
     ```
-    - NOTE: When loading an instruct checkpoint, use `--instruct_checkpoint` instead. This will also load the optimizer(s) state and resume from the stored step. You can reset the optimizer(s) with the flag `--reset-optimizers` and set the start step with the flag `--start-step`. E.g.: `--start-step 10`
+    - NOTE: When loading an instruct checkpoint, use `--instruct-checkpoint` or for DPO, `--dpo-checkpoint` instead. This will also load the optimizer(s) state and resume from the stored step. You can reset the optimizer(s) with the flag `--reset-optimizers` and set the start step with the flag `--start-step`. E.g.: `--start-step 10`
 
 - To train on multiple nodes with **1 or more GPUs per node**, configure each node as follows:
   - Static
@@ -237,7 +262,8 @@ The file `config.py` defines all the environment variables required.
 - More details on NCCL [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#environment-variables)
 
 ## Using Torch Profiler
-Details on the environment variables suggested in `examples/.env.example` can be found [here](https://docs.pytorch.org/tutorials/recipes/recipes/profiler_recipe.html).
+Torch profiler settings are configured in `config.py` under `GlobalConfig.torch_profiler`.
+More details on the profiler API can be found [here](https://docs.pytorch.org/tutorials/recipes/recipes/profiler_recipe.html).
 
 ## Running tests
 From the root folder:

--- a/checkpoints.py
+++ b/checkpoints.py
@@ -97,7 +97,7 @@ def save_checkpoint(
         checkpoint = {
             'model': model_state_dict,
             'step': step,
-            'config': config.model_dump(),
+            'config': config.model_dump(mode='json'),
             'optimizers': optimizer_state,
             'last_val_loss': float(last_val_loss),
             'best_val_loss': float(best_val_loss),
@@ -148,8 +148,8 @@ def load_checkpoint(
     state = torch.load(checkpoint_path, map_location='cpu', weights_only=True)
 
     step = state['step'] + 1
-    last_val_loss = state['last_val_loss']
-    best_val_loss = state['best_val_loss']
+    last_val_loss = state['last_val_loss'] if state['last_val_loss'] is not None else float('inf')
+    best_val_loss = state['best_val_loss'] if state['best_val_loss'] is not None else float('inf')
 
     model_state = state['model']
     assert type(model_state) in {OrderedDict, dict}

--- a/checkpoints.py
+++ b/checkpoints.py
@@ -50,7 +50,6 @@ def manage_checkpoints(directory, max_files, step, pbar=None):
 def save_checkpoint(
     checkpoint_dir,
     model,
-    model_config,
     config,
     step,
     last_val_loss,
@@ -98,8 +97,7 @@ def save_checkpoint(
         checkpoint = {
             'model': model_state_dict,
             'step': step,
-            'model_config': model_config.to_dict(),
-            'config': config.to_summary_dict(include_model_config=False),
+            'config': config.model_dump(),
             'optimizers': optimizer_state,
             'last_val_loss': float(last_val_loss),
             'best_val_loss': float(best_val_loss),

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class DeviceType(str, Enum):
     CUDA = 'cuda'
 
 class TrainingStage(str, Enum):
-    PRETRAIN = 'pretrain'
+    PRETRAINING = 'pretraining'
     INSTRUCT = 'instruct'
     DPO = 'dpo'
 
@@ -26,16 +26,24 @@ class ThirdPartyConfig(BaseSettings):
     hf_token: Annotated[str | None, Field(alias='HF_TOKEN', exclude=True)] = None
     hf_home: str = Field(default='./cache', alias='HF_HOME')
 
+class DatasetPreparationConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    hf_include_source_id: bool = False
+    mp_pool_chunk_size: int = 64
+    hf_map_batch_size: int = 1000
+    hf_map_writer_batch_size: int = 1000
+
 class RuntimeConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     device_type: DeviceType = DeviceType.CUDA
     training_precision: TrainingPrecision = TrainingPrecision.BF16
     use_torch_compile: bool = False
-    use_fsdp: bool = False
+    use_fsdp: bool = True
+    number_of_cpu_processes: int = 0
 
 class MoEConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = False
+    enabled: bool = True
     num_experts: int = 8
     expert_dim: int = 768
     top_k: int = 2
@@ -57,18 +65,22 @@ class ModelConfig(BaseModel):
     max_seq_len: int = 1024
     moe: MoEConfig = Field(default_factory=MoEConfig)
 
+class PromptConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    system_prompt: str = 'You are a helpful AI assistant'
+
 class TrainingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    stage: TrainingStage = TrainingStage.PRETRAIN
+    stage: TrainingStage = TrainingStage.DPO
     seed: int = 42
     total_batch_size: int = 524288
-    max_steps: int = -1
-    early_stopping_patience: int = 1_000_000
+    max_steps: int = 200
+    early_stopping_patience: int = 200
     early_stopping_patience_skip_steps: int = 0
 
 class EvalTaskConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    every_x_steps: int = 2
+    every_x_steps: int = -1
     number_of_examples: int = 200
 
 class EvalsConfig(BaseModel):
@@ -77,30 +89,44 @@ class EvalsConfig(BaseModel):
     winogrande: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
     arc_challenge: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
 
+class DatasetPreparationPathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    pretraining_target_path: str = './datasets/pretraining'
+    instruct_target_path: str = './datasets/instruct'
+    dpo_target_path: str = './datasets/dpo'
+
+class DataloaderPathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    pretraining_root_path: str = './datasets/pretraining'
+    instruct_root_path: str = './datasets/instruct'
+    dpo_root_path: str = './datasets/dpo'
+
 class EvalPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     hellaswag_path: str = './datasets/hellaswag'
     winogrande_path: str = './datasets/winogrande'
     arc_challenge_path: str = './datasets/arc_challenge'
 
-class DataloaderPathsConfig(BaseModel):
+class CheckpointPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    pretrain_root_path: str = './datasets/pretrain'
-    instruct_root_path: str = './datasets/instruct'
-    dpo_root_path: str = './datasets/dpo'
-
-class CheckpointsPathConfig(BaseModel):
-    pass
+    pretraining_save_path: str = './checkpoints/pretraining'
+    pretraining_load_path: str = './checkpoints/pretraining'
+    instruct_save_path: str = './checkpoints/instruct'
+    instruct_load_path: str = './checkpoints/instruct'
+    dpo_save_path: str = './checkpoints/dpo'
+    dpo_load_path: str = './checkpoints/dpo'
 
 class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
+    data_preparation: DatasetPreparationPathsConfig = Field(default_factory=DatasetPreparationPathsConfig)
+    dataloaders: DataloaderPathsConfig = Field(default_factory=DataloaderPathsConfig)
     evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
     test_prompts_path: str = './test_prompts.json'
-    dataloaders: DataloaderPathsConfig = Field(default_factory=DataloaderPathsConfig)
+    checkpoints: CheckpointPathsConfig = Field(default_factory=CheckpointPathsConfig)
 
 class GenerationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    generate_every_x_steps: int = 2
+    generate_every_x_steps: int = 1
     max_test_gen_len: int = 256
 
 class TokenizerConfig(BaseModel):
@@ -111,98 +137,92 @@ class TokenizerConfig(BaseModel):
 
 class LoRAConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = False
+    enabled: bool = True
+    rank: int = 16
+    alpha: int = 8
+    dropout: float = 0.05
+    target_modules: list[str] = Field(default_factory=lambda: ['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
 
-class GlobalConfig(BaseSettings):
+class DistillationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
+    enabled: bool = True
+    temperature: float = 2.0
+    teacher_model_checkpoint: str = 'HuggingFaceTB/SmolLM2-360M'
 
+class DPOConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    beta: float = 0.1
+
+class AdamWConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    min_lr: float = 3e-5
+    max_lr: float = 3e-4
+    weight_decay: float = 0.1
+    betas: tuple[float, float] = (0.9, 0.95)
+    use_fused: bool | None = None
+    warmup_steps: int = 2000
+
+class MuonConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool = True
+    min_lr: float = 3e-5
+    max_lr: float = 3e-4
+    weight_decay: float = 0.0
+    momentum: float = 0.95
+    warmup_steps: int = 2000
+
+class OptimizersConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    adamw: AdamWConfig = Field(default_factory=AdamWConfig)
+    muon: MuonConfig = Field(default_factory=MuonConfig)
+
+class WandbConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool = False
+    project_name: str = 'gradient-garden'
+    run_name: str = 'debug'
+
+class TorchProfilerConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool = False
+    schedule_skip_first: int = 0
+    schedule_wait: int = 1
+    schedule_warmup: int = 1
+    schedule_active: int = 1
+    schedule_repeat: int = 0
+
+class ValidationConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    validate_every_x_steps: int = -1
+    validation_steps: int = 100
+
+class CheckpointingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    save_checkpoints: bool = False
+    save_best_only: bool = False
+    save_every_x_steps: int = 1
+    max_number_checkpoints: int = 5
+
+class GlobalConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     third_party: ThirdPartyConfig = Field(default_factory=ThirdPartyConfig)
+    data_preparation: DatasetPreparationConfig = Field(default_factory=DatasetPreparationConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     model: ModelConfig = Field(default_factory=ModelConfig)
+    prompts: PromptConfig = Field(default_factory=PromptConfig)
     training: TrainingConfig = Field(default_factory=TrainingConfig)
     evals: EvalsConfig = Field(default_factory=EvalsConfig)
     paths: PathsConfig = Field(default_factory=PathsConfig)
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     tokenizer: TokenizerConfig = Field(default_factory=TokenizerConfig)
-
-    # # datasets
-    # pretrain_dataset_target_path: str = Field(alias='HF_PRETRAIN_DATASET_TARGET_PATH')
-    # instruct_dataset_target_path: str = Field(alias='HF_INSTRUCT_DATASET_TARGET_PATH')
-    # dpo_dataset_target_path: str = Field(alias='HF_DPO_DATASET_TARGET_PATH')
-
-    # hf_include_source_id: bool = Field(default=False, alias='HF_INCLUDE_SOURCE_ID')
-
-    # # processes and batch sizes
-    # number_of_cpu_processes: int = Field(default=0, alias='NUMBER_OF_CPU_PROCESSES')
-    # mp_pool_chunk_size: int = Field(default=64, alias='MP_POOL_CHUNK_SIZE')
-    # hf_map_batch_size: int = Field(default=1000, alias='HF_MAP_BATCH_SIZE')
-    # hf_map_writer_batch_size: int = Field(default=1000, alias='HF_MAP_WRITER_BATCH_SIZE')
-
-    # # torch profiler
-    # torch_profiler_enabled: bool = Field(default=False, alias='TORCH_PROFILER_ENABLED')
-    # torch_profiler_schedule_skip_first: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_SKIP_FIRST')
-    # torch_profiler_schedule_wait: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WAIT')
-    # torch_profiler_schedule_warmup: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WARMUP')
-    # torch_profiler_schedule_active: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_ACTIVE')
-    # torch_profiler_schedule_repeat: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_REPEAT')
-
-
-    # # paths for eval datasets
-    # hellaswag_path: str = Field(alias='HELLASWAG_PATH')
-    # winogrande_path: str = Field(alias='WINOGRANDE_PATH')
-    # arc_challenge_path: str = Field(alias='ARC_CHALLENGE_PATH')
-
-    # # system prompt
-    # system_prompt: str = Field(default='You are a helpful AI assistant', alias='SYSTEM_PROMPT')
-
-    # # save / load path
-    # pretrain_save_checkpoints_path: str = Field(alias='PRETRAIN_SAVE_CHECKPOINTS_PATH')
-    # pretrain_load_checkpoints_path: str = Field(alias='PRETRAIN_LOAD_CHECKPOINTS_PATH')
-    # instruct_save_checkpoints_path: str = Field(alias='INSTRUCT_SAVE_CHECKPOINTS_PATH')
-    # instruct_load_checkpoints_path: str = Field(alias='INSTRUCT_LOAD_CHECKPOINTS_PATH')
-    # dpo_save_checkpoints_path: str = Field(alias='DPO_SAVE_CHECKPOINTS_PATH')
-    # dpo_load_checkpoints_path: str = Field(alias='DPO_LOAD_CHECKPOINTS_PATH')
-
-    # save_checkpoints: bool = Field(default=False, alias='SAVE_CHECKPOINTS')
-    # save_best_only: bool = Field(default=False, alias='SAVE_BEST_ONLY')
-    # save_every_x_steps: int = Field(alias='SAVE_EVERY_X_STEPS')
-    # max_number_checkpoints: int = Field(default=2, alias='MAX_NUMBER_CHECKPOINTS')
-
-    # # wandb
-    # wandb_enabled: bool = Field(default=False, alias='WANDB_ENABLED')
-    # wandb_project_name: str = Field(alias='WANDB_PROJECT_NAME')
-    # wandb_run_name: str = Field(default=None, alias='WANDB_RUN_NAME')
-
-
-    # adamw_min_lr: float = Field(alias='ADAMW_MIN_LR')
-    # adamw_max_lr: float = Field(alias='ADAMW_MAX_LR')
-    # adamw_weight_decay: float = Field(alias='ADAMW_WEIGHT_DECAY')
-    # adamw_betas: Tuple[float, float] = Field(default=(0.9, 0.95), alias='ADAMW_BETAS')
-    # adamw_use_fused: Annotated[bool | None, Field(alias='ADAMW_USE_FUSED')] = None
-    # adamw_warmup_steps: int = Field(alias='ADAMW_WARMUP_STEPS')
-
-    # use_muon: bool = Field(default=False, alias='USE_MUON')
-    # muon_min_lr: float = Field(alias='MUON_MIN_LR')
-    # muon_max_lr: float = Field(alias='MUON_MAX_LR')
-    # muon_weight_decay: float = Field(alias='MUON_WEIGHT_DECAY')
-    # muon_momentum: float = Field(alias='MUON_MOMENTUM', default=0.95)
-    # muon_warmup_steps: int = Field(alias='MUON_WARMUP_STEPS')
-
-    # dpo_beta: float = Field(default=0.1, alias='DPO_BETA')
-    # is_model_distillation: bool = Field(alias='IS_MODEL_DISTILLATION')
-    # distillation_temperature: float = Field(alias='DISTILLATION_TEMPERATURE')
-    # # The teacher model is loader via huggingface API: AutoModelForCausalLM.from_pretrained(teacher_model_checkpoint, ...) so needs to ve a valid checkpoint.
-    # teacher_model_checkpoint: str = Field(alias='TEACHER_MODEL_CHECKPOINT')
-    # lora_enabled: bool = Field(default=False, alias='LORA_ENABLED')
-    # lora_rank: int = Field(default=16, alias='LORA_RANK')
-    # lora_alpha: int = Field(default=8, alias='LORA_ALPHA')
-    # lora_dropout: float = Field(default=0.05, alias='LORA_DROPOUT')
-    # lora_target_modules: list[str] = Field(alias='LORA_TARGET_MODULES')
-
-
-    # # validation
-    # validate_every_x_steps: int = Field(alias='VALIDATE_EVERY_X_STEPS')
-    # validation_steps: int = Field(alias='VALIDATION_STEPS')
+    lora: LoRAConfig = Field(default_factory=LoRAConfig)
+    distillation: DistillationConfig = Field(default_factory=DistillationConfig)
+    dpo: DPOConfig = Field(default_factory=DPOConfig)
+    optimizers: OptimizersConfig = Field(default_factory=OptimizersConfig)
+    wandb: WandbConfig = Field(default_factory=WandbConfig)
+    torch_profiler: TorchProfilerConfig = Field(default_factory=TorchProfilerConfig)
+    validation: ValidationConfig = Field(default_factory=ValidationConfig)
+    checkpointing: CheckpointingConfig = Field(default_factory=CheckpointingConfig)
 
     def model_post_init(self, __context: any) -> None:
         # Sets default paths for huggingface

--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class RuntimeConfig(BaseModel):
     training_precision: TrainingPrecision = TrainingPrecision.BF16
     use_torch_compile: bool = False
     use_fsdp: bool = True
-    number_of_cpu_processes: int = 0
+    number_of_cpu_processes: int = 32
 
 class MoEConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -89,17 +89,11 @@ class EvalsConfig(BaseModel):
     winogrande: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
     arc_challenge: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
 
-class DatasetPreparationPathsConfig(BaseModel):
+class DatasetPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    pretraining_target_path: str = './datasets/pretraining'
-    instruct_target_path: str = './datasets/instruct'
-    dpo_target_path: str = './datasets/dpo'
-
-class DataloaderPathsConfig(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-    pretraining_root_path: str = './datasets/pretraining'
-    instruct_root_path: str = './datasets/instruct'
-    dpo_root_path: str = './datasets/dpo'
+    pretraining_path: str = './datasets/pretraining'
+    instruct_path: str = './datasets/instruct'
+    dpo_path: str = './datasets/dpo'
 
 class EvalPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -118,8 +112,7 @@ class CheckpointPathsConfig(BaseModel):
 
 class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    data_preparation: DatasetPreparationPathsConfig = Field(default_factory=DatasetPreparationPathsConfig)
-    dataloaders: DataloaderPathsConfig = Field(default_factory=DataloaderPathsConfig)
+    datasets: DatasetPathsConfig = Field(default_factory=DatasetPathsConfig)
     evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
     test_prompts_path: str = './test_prompts.json'
     checkpoints: CheckpointPathsConfig = Field(default_factory=CheckpointPathsConfig)

--- a/config.py
+++ b/config.py
@@ -1,10 +1,9 @@
 import os
-import yaml
 
 from pydantic import BaseModel, Field, ConfigDict
 from pydantic_settings import BaseSettings
 from enum import Enum
-from typing import Tuple, Annotated
+from typing import Any, Annotated
 
 
 class DeviceType(str, Enum):
@@ -38,12 +37,12 @@ class RuntimeConfig(BaseModel):
     device_type: DeviceType = DeviceType.CUDA
     training_precision: TrainingPrecision = TrainingPrecision.BF16
     use_torch_compile: bool = False
-    use_fsdp: bool = True
-    number_of_cpu_processes: int = 32
+    use_fsdp: bool = False
+    number_of_cpu_processes: int = 16
 
 class MoEConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = True
+    enabled: bool = False
     num_experts: int = 8
     expert_dim: int = 768
     top_k: int = 2
@@ -75,13 +74,15 @@ class TrainingConfig(BaseModel):
     seed: int = 42
     total_batch_size: int = 524288
     max_steps: int = 200
-    early_stopping_patience: int = 200
+    early_stopping_patience: int = 100
     early_stopping_patience_skip_steps: int = 0
 
 class EvalTaskConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    every_x_steps: int = 1
+    every_x_steps: int = -1
     number_of_examples: int = 200
+    run_on_first_step: bool = False
+    run_on_last_step: bool = False
 
 class EvalsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -119,8 +120,10 @@ class PathsConfig(BaseModel):
 
 class GenerationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    generate_every_x_steps: int = 1
+    every_x_steps: int = -1
     max_test_gen_len: int = 256
+    run_on_first_step: bool = False
+    run_on_last_step: bool = False
 
 class TokenizerConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -130,7 +133,7 @@ class TokenizerConfig(BaseModel):
 
 class LoRAConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = True
+    enabled: bool = False
     rank: int = 16
     alpha: int = 8
     dropout: float = 0.05
@@ -138,7 +141,7 @@ class LoRAConfig(BaseModel):
 
 class DistillationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = True
+    enabled: bool = False
     temperature: float = 2.0
     teacher_model_checkpoint: str = 'HuggingFaceTB/SmolLM2-360M'
 
@@ -153,16 +156,16 @@ class AdamWConfig(BaseModel):
     weight_decay: float = 0.1
     betas: tuple[float, float] = (0.9, 0.95)
     use_fused: bool | None = None
-    warmup_steps: int = 2000
+    warmup_steps: int = 20
 
 class MuonConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    enabled: bool = True
+    enabled: bool = False
     min_lr: float = 3e-5
     max_lr: float = 3e-4
     weight_decay: float = 0.0
     momentum: float = 0.95
-    warmup_steps: int = 2000
+    warmup_steps: int = 20
 
 class OptimizersConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -186,15 +189,19 @@ class TorchProfilerConfig(BaseModel):
 
 class ValidationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    validate_every_x_steps: int = -1
+    every_x_steps: int = -1
     validation_steps: int = 100
+    run_on_first_step: bool = False
+    run_on_last_step: bool = False
 
 class CheckpointingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     save_checkpoints: bool = False
     save_best_only: bool = False
-    save_every_x_steps: int = 1
+    every_x_steps: int = 50
     max_number_checkpoints: int = 5
+    run_on_first_step: bool = False
+    run_on_last_step: bool = False
 
 class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -217,7 +224,7 @@ class GlobalConfig(BaseModel):
     validation: ValidationConfig = Field(default_factory=ValidationConfig)
     checkpointing: CheckpointingConfig = Field(default_factory=CheckpointingConfig)
 
-    def model_post_init(self, __context: any) -> None:
+    def model_post_init(self, __context: Any) -> None:
         # Sets default paths for huggingface
         os.environ['HF_HOME'] = self.third_party.hf_home
         os.environ['HF_DATASETS_CACHE'] = f'{self.third_party.hf_home}/datasets'

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
+import yaml
 
-from pydantic import Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict
 from pydantic_settings import BaseSettings
 from enum import Enum
 from typing import Tuple, Annotated
@@ -19,338 +20,194 @@ class TrainingPrecision(str, Enum):
     FP16 = 'fp16'
     FP32 = 'fp32'
 
-class TrainConfig(BaseSettings):
-    # third party envs
+class ThirdPartyConfig(BaseSettings):
+    model_config = ConfigDict(env_file='.env', extra='ignore')
     wandb_api_key: Annotated[str | None, Field(alias='WANDB_API_KEY', exclude=True)] = None
     hf_token: Annotated[str | None, Field(alias='HF_TOKEN', exclude=True)] = None
     hf_home: str = Field(default='./cache', alias='HF_HOME')
 
-    # datasets
-    pretrain_dataset_target_path: str = Field(alias='HF_PRETRAIN_DATASET_TARGET_PATH')
-    instruct_dataset_target_path: str = Field(alias='HF_INSTRUCT_DATASET_TARGET_PATH')
-    dpo_dataset_target_path: str = Field(alias='HF_DPO_DATASET_TARGET_PATH')
+class RuntimeConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    device_type: DeviceType = DeviceType.CUDA
+    training_precision: TrainingPrecision = TrainingPrecision.BF16
+    use_torch_compile: bool = False
+    use_fsdp: bool = False
 
-    hf_include_source_id: bool = Field(default=False, alias='HF_INCLUDE_SOURCE_ID')
+class MoEConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool = False
+    num_experts: int = 8
+    expert_dim: int = 768
+    top_k: int = 2
+    load_balancing_coef: float = 1e-2
+    z_loss_coef: float = 1e-3
+    compute_stats: bool = True
 
-    # processes and batch sizes
-    number_of_cpu_processes: int = Field(default=0, alias='NUMBER_OF_CPU_PROCESSES')
-    mp_pool_chunk_size: int = Field(default=64, alias='MP_POOL_CHUNK_SIZE')
-    hf_map_batch_size: int = Field(default=1000, alias='HF_MAP_BATCH_SIZE')
-    hf_map_writer_batch_size: int = Field(default=1000, alias='HF_MAP_WRITER_BATCH_SIZE')
+class ModelConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    dim: int = 768
+    n_layers: int = 16
+    n_heads: int = 16
+    n_kv_heads: int = 8
+    multiple_of: int = 1024
+    ffn_dim_multiplier: float = 1.0
+    norm_eps: float = 1e-5
+    rope_theta: float = 500000.0
+    max_batch_size: int = 4
+    max_seq_len: int = 1024
+    moe: MoEConfig = Field(default_factory=MoEConfig)
 
-    # torch profiler
-    torch_profiler_enabled: bool = Field(default=False, alias='TORCH_PROFILER_ENABLED')
-    torch_profiler_schedule_skip_first: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_SKIP_FIRST')
-    torch_profiler_schedule_wait: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WAIT')
-    torch_profiler_schedule_warmup: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WARMUP')
-    torch_profiler_schedule_active: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_ACTIVE')
-    torch_profiler_schedule_repeat: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_REPEAT')
+class TrainingConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    stage: TrainingStage = TrainingStage.PRETRAIN
+    seed: int = 42
+    total_batch_size: int = 524288
+    max_steps: int = -1
+    early_stopping_patience: int = 1_000_000
+    early_stopping_patience_skip_steps: int = 0
 
-    # paths for dataloaders
-    pretrain_dataloader_root_path: str = Field(alias='PRETRAIN_DATALOADER_ROOT_PATH')
-    instruct_dataloader_root_path: str = Field(alias='INSTRUCT_DATALOADER_ROOT_PATH')
-    dpo_dataloader_root_path: str = Field(alias='DPO_DATALOADER_ROOT_PATH')
+class EvalTaskConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    every_x_steps: int = 2
+    number_of_examples: int = 200
 
-    # paths for eval datasets
-    hellaswag_path: str = Field(alias='HELLASWAG_PATH')
-    winogrande_path: str = Field(alias='WINOGRANDE_PATH')
-    arc_challenge_path: str = Field(alias='ARC_CHALLENGE_PATH')
+class EvalsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    hellaswag: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
+    winogrande: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
+    arc_challenge: EvalTaskConfig = Field(default_factory=EvalTaskConfig)
 
-    # system prompt
-    system_prompt: str = Field(default='You are a helpful AI assistant', alias='SYSTEM_PROMPT')
+class EvalPathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    hellaswag_path: str = './datasets/hellaswag'
+    winogrande_path: str = './datasets/winogrande'
+    arc_challenge_path: str = './datasets/arc_challenge'
 
-    # save / load path
-    pretrain_save_checkpoints_path: str = Field(alias='PRETRAIN_SAVE_CHECKPOINTS_PATH')
-    pretrain_load_checkpoints_path: str = Field(alias='PRETRAIN_LOAD_CHECKPOINTS_PATH')
-    instruct_save_checkpoints_path: str = Field(alias='INSTRUCT_SAVE_CHECKPOINTS_PATH')
-    instruct_load_checkpoints_path: str = Field(alias='INSTRUCT_LOAD_CHECKPOINTS_PATH')
-    dpo_save_checkpoints_path: str = Field(alias='DPO_SAVE_CHECKPOINTS_PATH')
-    dpo_load_checkpoints_path: str = Field(alias='DPO_LOAD_CHECKPOINTS_PATH')
+class DataloaderPathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    pretrain_root_path: str = './datasets/pretrain'
+    instruct_root_path: str = './datasets/instruct'
+    dpo_root_path: str = './datasets/dpo'
 
-    save_checkpoints: bool = Field(default=False, alias='SAVE_CHECKPOINTS')
-    save_best_only: bool = Field(default=False, alias='SAVE_BEST_ONLY')
-    save_every_x_steps: int = Field(alias='SAVE_EVERY_X_STEPS')
-    max_number_checkpoints: int = Field(default=2, alias='MAX_NUMBER_CHECKPOINTS')
+class CheckpointsPathConfig(BaseModel):
+    pass
 
-    # wandb
-    wandb_enabled: bool = Field(default=False, alias='WANDB_ENABLED')
-    wandb_project_name: str = Field(alias='WANDB_PROJECT_NAME')
-    wandb_run_name: str = Field(default=None, alias='WANDB_RUN_NAME')
+class PathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
+    test_prompts_path: str = './test_prompts.json'
+    dataloaders: DataloaderPathsConfig = Field(default_factory=DataloaderPathsConfig)
 
-    # tokenizer model path
-    tokenizer_checkpoint_path: str = Field(alias='TOKENIZER_CHECKPOINT_PATH')
-    huggingface_tokenizer: bool = Field(default=True, alias='HUGGINGFACE_TOKENIZER')
+class GenerationConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    generate_every_x_steps: int = 2
+    max_test_gen_len: int = 256
 
-    # value to mask the padded tokens in the loss calculation
-    ignore_index: int = Field(default=-100, alias='IGNORE_INDEX')
+class TokenizerConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    checkpoint_path: str = 'HuggingFaceTB/SmolLM2-360M'
+    huggingface_tokenizer: bool = True
+    ignore_index: int = -100
 
-    # train config
-    seed: int = Field(default=42, alias='SEED')
-    device_type: DeviceType = Field(default=DeviceType.CUDA, alias='DEVICE_TYPE')
-    training_precision: TrainingPrecision = Field(default=TrainingPrecision.BF16, alias='TRAINING_PRECISION')
-    training_stage: TrainingStage = Field(default=TrainingStage.PRETRAIN, alias='TRAINING_STAGE')
-    total_batch_size: int = Field(alias='TOTAL_BATCH_SIZE')
-    max_steps: int = Field(default=-1, alias='MAX_STEPS') # If not set, it is aprox calculated
+class LoRAConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    enabled: bool = False
 
-    adamw_min_lr: float = Field(alias='ADAMW_MIN_LR')
-    adamw_max_lr: float = Field(alias='ADAMW_MAX_LR')
-    adamw_weight_decay: float = Field(alias='ADAMW_WEIGHT_DECAY')
-    adamw_betas: Tuple[float, float] = Field(default=(0.9, 0.95), alias='ADAMW_BETAS')
-    adamw_use_fused: Annotated[bool | None, Field(alias='ADAMW_USE_FUSED')] = None
-    adamw_warmup_steps: int = Field(alias='ADAMW_WARMUP_STEPS')
+class GlobalConfig(BaseSettings):
+    model_config = ConfigDict(extra='forbid')
 
-    use_muon: bool = Field(default=False, alias='USE_MUON')
-    muon_min_lr: float = Field(alias='MUON_MIN_LR')
-    muon_max_lr: float = Field(alias='MUON_MAX_LR')
-    muon_weight_decay: float = Field(alias='MUON_WEIGHT_DECAY')
-    muon_momentum: float = Field(alias='MUON_MOMENTUM', default=0.95)
-    muon_warmup_steps: int = Field(alias='MUON_WARMUP_STEPS')
+    third_party: ThirdPartyConfig = Field(default_factory=ThirdPartyConfig)
+    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
+    model: ModelConfig = Field(default_factory=ModelConfig)
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+    evals: EvalsConfig = Field(default_factory=EvalsConfig)
+    paths: PathsConfig = Field(default_factory=PathsConfig)
+    generation: GenerationConfig = Field(default_factory=GenerationConfig)
+    tokenizer: TokenizerConfig = Field(default_factory=TokenizerConfig)
 
-    early_stopping_patience: int = Field(alias='EARLY_STOPPING_PATIENCE')
-    early_stopping_patience_skip_steps: int = Field(alias='EARLY_STOPPING_PATIENCE_SKIP_STEPS')
-    dpo_beta: float = Field(default=0.1, alias='DPO_BETA')
-    is_model_distillation: bool = Field(alias='IS_MODEL_DISTILLATION')
-    distillation_temperature: float = Field(alias='DISTILLATION_TEMPERATURE')
-    # The teacher model is loader via huggingface API: AutoModelForCausalLM.from_pretrained(teacher_model_checkpoint, ...) so needs to ve a valid checkpoint.
-    teacher_model_checkpoint: str = Field(alias='TEACHER_MODEL_CHECKPOINT')
-    lora_enabled: bool = Field(default=False, alias='LORA_ENABLED')
-    lora_rank: int = Field(default=16, alias='LORA_RANK')
-    lora_alpha: int = Field(default=8, alias='LORA_ALPHA')
-    lora_dropout: float = Field(default=0.05, alias='LORA_DROPOUT')
-    lora_target_modules: list[str] = Field(alias='LORA_TARGET_MODULES')
-    use_torch_compile: bool = Field(default=False, alias='USE_TORCH_COMPILE') # Will add more options later.
-    use_fsdp: bool = Field(default=False, alias='USE_FSDP')
+    # # datasets
+    # pretrain_dataset_target_path: str = Field(alias='HF_PRETRAIN_DATASET_TARGET_PATH')
+    # instruct_dataset_target_path: str = Field(alias='HF_INSTRUCT_DATASET_TARGET_PATH')
+    # dpo_dataset_target_path: str = Field(alias='HF_DPO_DATASET_TARGET_PATH')
 
-    # validation
-    validate_every_x_steps: int = Field(alias='VALIDATE_EVERY_X_STEPS')
-    validation_steps: int = Field(alias='VALIDATION_STEPS')
+    # hf_include_source_id: bool = Field(default=False, alias='HF_INCLUDE_SOURCE_ID')
 
-    # evals
-    hellaswag_every_x_steps: int = Field(alias='HELLASWAG_EVERY_X_STEPS')
-    hellaswag_number_of_examples: int = Field(alias='HELLASWAG_NUMBER_OF_EXAMPLES')
-    winogrande_every_x_steps: int = Field(alias='WINOGRANDE_EVERY_X_STEPS')
-    winogrande_number_of_examples: int = Field(alias='WINOGRANDE_NUMBER_OF_EXAMPLES')
-    arc_challenge_every_x_steps: int = Field(alias='ARC_CHALLENGE_EVERY_X_STEPS')
-    arc_challenge_number_of_examples: int = Field(alias='ARC_CHALLENGE_NUMBER_OF_EXAMPLES')
+    # # processes and batch sizes
+    # number_of_cpu_processes: int = Field(default=0, alias='NUMBER_OF_CPU_PROCESSES')
+    # mp_pool_chunk_size: int = Field(default=64, alias='MP_POOL_CHUNK_SIZE')
+    # hf_map_batch_size: int = Field(default=1000, alias='HF_MAP_BATCH_SIZE')
+    # hf_map_writer_batch_size: int = Field(default=1000, alias='HF_MAP_WRITER_BATCH_SIZE')
 
-    # generation
-    test_prompts_path: str = Field(alias='TEST_PROMPTS_FILE')
-    generate_every_x_steps: int = Field(alias='GENERATE_EVERY_X_STEPS')
-    max_test_gen_len: int = Field(alias='MAX_TEST_GEN_LEN')
+    # # torch profiler
+    # torch_profiler_enabled: bool = Field(default=False, alias='TORCH_PROFILER_ENABLED')
+    # torch_profiler_schedule_skip_first: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_SKIP_FIRST')
+    # torch_profiler_schedule_wait: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WAIT')
+    # torch_profiler_schedule_warmup: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_WARMUP')
+    # torch_profiler_schedule_active: int = Field(default=1, alias='TORCH_PROFILER_SCHEDULE_ACTIVE')
+    # torch_profiler_schedule_repeat: int = Field(default=0, alias='TORCH_PROFILER_SCHEDULE_REPEAT')
 
-    # model architecture config
-    dim: int = Field(default=768, alias='DIM')
-    n_layers: int = Field(default=16, alias='N_LAYERS')
-    n_heads: int = Field(default=16, alias='N_HEADS')
-    n_kv_heads: int = Field(default=8, alias='N_KV_HEADS')
-    multiple_of: int = Field(default=1024, alias='MULTIPLE_OF')
-    ffn_dim_multiplier: float = Field(default=1.0, alias='FFN_DIM_MULTIPLIER')
-    norm_eps: float = Field(default=1e-05, alias='NORM_EPS')
-    is_rope_cis: bool = Field(default=False, alias='IS_ROPE_CIS')
-    rope_theta: float = Field(default=500000.0, alias='ROPE_THETA')
-    max_batch_size: int = Field(default=4, alias='MAX_BATCH_SIZE')
-    max_seq_len: int = Field(default=1024, alias='MAX_SEQ_LEN')
-    is_moe: bool = Field(default=False, alias='IS_MOE')
-    moe_num_experts: int = Field(alias='MOE_NUM_EXPERTS')
-    moe_expert_dim: int = Field(alias='MOE_EXPERT_DIM')
-    moe_top_k: int = Field(alias='MOE_TOP_K')
-    moe_load_balancing_coef: float = Field(alias='MOE_LOAD_BALANCING_COEF')
-    moe_z_loss_coef: float = Field(alias='MOE_Z_LOSS_COEF')
-    moe_compute_stats: bool = Field(alias='MOE_COMPUTE_STATS')
 
-    #### DERIVED PROPERTIES ####
-    is_pretraining: bool = Field(default=False, repr=False)
-    is_instruct_training: bool = Field(default=False, repr=False)
-    is_dpo_training: bool = Field(default=False, repr=False)
+    # # paths for eval datasets
+    # hellaswag_path: str = Field(alias='HELLASWAG_PATH')
+    # winogrande_path: str = Field(alias='WINOGRANDE_PATH')
+    # arc_challenge_path: str = Field(alias='ARC_CHALLENGE_PATH')
 
-    dataloader_root_path: str = Field(default='', repr=False)
-    save_checkpoints_path: str = Field(default='', repr=False)
+    # # system prompt
+    # system_prompt: str = Field(default='You are a helpful AI assistant', alias='SYSTEM_PROMPT')
+
+    # # save / load path
+    # pretrain_save_checkpoints_path: str = Field(alias='PRETRAIN_SAVE_CHECKPOINTS_PATH')
+    # pretrain_load_checkpoints_path: str = Field(alias='PRETRAIN_LOAD_CHECKPOINTS_PATH')
+    # instruct_save_checkpoints_path: str = Field(alias='INSTRUCT_SAVE_CHECKPOINTS_PATH')
+    # instruct_load_checkpoints_path: str = Field(alias='INSTRUCT_LOAD_CHECKPOINTS_PATH')
+    # dpo_save_checkpoints_path: str = Field(alias='DPO_SAVE_CHECKPOINTS_PATH')
+    # dpo_load_checkpoints_path: str = Field(alias='DPO_LOAD_CHECKPOINTS_PATH')
+
+    # save_checkpoints: bool = Field(default=False, alias='SAVE_CHECKPOINTS')
+    # save_best_only: bool = Field(default=False, alias='SAVE_BEST_ONLY')
+    # save_every_x_steps: int = Field(alias='SAVE_EVERY_X_STEPS')
+    # max_number_checkpoints: int = Field(default=2, alias='MAX_NUMBER_CHECKPOINTS')
+
+    # # wandb
+    # wandb_enabled: bool = Field(default=False, alias='WANDB_ENABLED')
+    # wandb_project_name: str = Field(alias='WANDB_PROJECT_NAME')
+    # wandb_run_name: str = Field(default=None, alias='WANDB_RUN_NAME')
+
+
+    # adamw_min_lr: float = Field(alias='ADAMW_MIN_LR')
+    # adamw_max_lr: float = Field(alias='ADAMW_MAX_LR')
+    # adamw_weight_decay: float = Field(alias='ADAMW_WEIGHT_DECAY')
+    # adamw_betas: Tuple[float, float] = Field(default=(0.9, 0.95), alias='ADAMW_BETAS')
+    # adamw_use_fused: Annotated[bool | None, Field(alias='ADAMW_USE_FUSED')] = None
+    # adamw_warmup_steps: int = Field(alias='ADAMW_WARMUP_STEPS')
+
+    # use_muon: bool = Field(default=False, alias='USE_MUON')
+    # muon_min_lr: float = Field(alias='MUON_MIN_LR')
+    # muon_max_lr: float = Field(alias='MUON_MAX_LR')
+    # muon_weight_decay: float = Field(alias='MUON_WEIGHT_DECAY')
+    # muon_momentum: float = Field(alias='MUON_MOMENTUM', default=0.95)
+    # muon_warmup_steps: int = Field(alias='MUON_WARMUP_STEPS')
+
+    # dpo_beta: float = Field(default=0.1, alias='DPO_BETA')
+    # is_model_distillation: bool = Field(alias='IS_MODEL_DISTILLATION')
+    # distillation_temperature: float = Field(alias='DISTILLATION_TEMPERATURE')
+    # # The teacher model is loader via huggingface API: AutoModelForCausalLM.from_pretrained(teacher_model_checkpoint, ...) so needs to ve a valid checkpoint.
+    # teacher_model_checkpoint: str = Field(alias='TEACHER_MODEL_CHECKPOINT')
+    # lora_enabled: bool = Field(default=False, alias='LORA_ENABLED')
+    # lora_rank: int = Field(default=16, alias='LORA_RANK')
+    # lora_alpha: int = Field(default=8, alias='LORA_ALPHA')
+    # lora_dropout: float = Field(default=0.05, alias='LORA_DROPOUT')
+    # lora_target_modules: list[str] = Field(alias='LORA_TARGET_MODULES')
+
+
+    # # validation
+    # validate_every_x_steps: int = Field(alias='VALIDATE_EVERY_X_STEPS')
+    # validation_steps: int = Field(alias='VALIDATION_STEPS')
 
     def model_post_init(self, __context: any) -> None:
-        self.is_pretraining = self.training_stage == TrainingStage.PRETRAIN
-        self.is_instruct_training = self.training_stage == TrainingStage.INSTRUCT
-        self.is_dpo_training = self.training_stage == TrainingStage.DPO
+        # Sets default paths for huggingface
+        os.environ['HF_HOME'] = self.third_party.hf_home
+        os.environ['HF_DATASETS_CACHE'] = f'{self.third_party.hf_home}/datasets'
+        os.environ['HF_HUB_CACHE'] = f'{self.third_party.hf_home}/hub'
 
-        if self.is_pretraining:
-            self.dataloader_root_path = self.pretrain_dataloader_root_path
-            self.save_checkpoints_path = self.pretrain_save_checkpoints_path
-        elif self.is_instruct_training:
-            self.dataloader_root_path = self.instruct_dataloader_root_path
-            self.save_checkpoints_path = self.instruct_save_checkpoints_path
-        elif self.is_dpo_training:
-            self.dataloader_root_path = self.dpo_dataloader_root_path
-            self.save_checkpoints_path = self.dpo_save_checkpoints_path
-        else:
-            raise ValueError(f'Invalid training stage: {self.training_stage}')
-
-        self.configure_hf_environment()
-
-    def configure_hf_environment(self) -> None:
-        # Sets default paths for hf
-        os.environ['HF_HOME'] = self.hf_home
-        os.environ['HF_DATASETS_CACHE'] = f'{self.hf_home}/datasets'
-        os.environ['HF_HUB_CACHE'] = f'{self.hf_home}/hub'
-
-    def to_summary_dict(self, include_model_config: bool = True) -> dict:
-        data = self.model_dump(exclude={'wandb_api_key', 'hf_token'})
-        summary = {
-            'third_part': {
-                'hf_home': data['hf_home']
-            },
-            'runtime': {
-                'number_of_cpu_processes': data['number_of_cpu_processes'],
-                'mp_pool_chunk_size': data['mp_pool_chunk_size'],
-                'hf_map_batch_size': data['hf_map_batch_size'],
-                'hf_map_writer_batch_size': data['hf_map_writer_batch_size'],
-                'use_torch_compile': data['use_torch_compile'],
-                'use_fsdp': data['use_fsdp']
-            },
-            'torch_profiler': {
-                'torch_profiler_enabled': data['torch_profiler_enabled'],
-                'torch_profiler_schedule_skip_first': data['torch_profiler_schedule_skip_first'],
-                'torch_profiler_schedule_wait': data['torch_profiler_schedule_wait'],
-                'torch_profiler_schedule_warmup': data['torch_profiler_schedule_warmup'],
-                'torch_profiler_schedule_active': data['torch_profiler_schedule_active'],
-                'torch_profiler_schedule_repeat': data['torch_profiler_schedule_repeat']
-            },
-            'datasets': {
-                'pretrain_dataset_target_path': data['pretrain_dataset_target_path'],
-                'instruct_dataset_target_path': data['instruct_dataset_target_path'],
-                'dpo_dataset_target_path': data['dpo_dataset_target_path'],
-                'hf_include_source_id': data['hf_include_source_id']
-            },
-            'eval_data': {
-                'hellaswag_path': data['hellaswag_path'],
-                'winogrande_path': data['winogrande_path'],
-                'arc_challenge_path': data['arc_challenge_path']
-            },
-            'generation_data': {
-                'test_prompts_path': data['test_prompts_path']
-            },
-            'dataloaders': {
-                'pretrain_dataloader_root_path': data['pretrain_dataloader_root_path'],
-                'instruct_dataloader_root_path': data['instruct_dataloader_root_path'],
-                'dpo_dataloader_root_path': data['dpo_dataloader_root_path'],
-                'dataloader_root_path': data['dataloader_root_path']
-            },
-            'checkpoints': {
-                'pretrain_save_checkpoints_path': data['pretrain_save_checkpoints_path'],
-                'pretrain_load_checkpoints_path': data['pretrain_load_checkpoints_path'],
-                'instruct_save_checkpoints_path': data['instruct_save_checkpoints_path'],
-                'instruct_load_checkpoints_path': data['instruct_load_checkpoints_path'],
-                'dpo_save_checkpoints_path': data['dpo_save_checkpoints_path'],
-                'dpo_load_checkpoints_path': data['dpo_load_checkpoints_path'],
-                'save_checkpoints': data['save_checkpoints'],
-                'save_best_only': data['save_best_only'],
-                'save_every_x_steps': data['save_every_x_steps'],
-                'max_number_checkpoints': data['max_number_checkpoints']
-            },
-            'wandb': {
-                'wandb_enabled': data['wandb_enabled'],
-                'wandb_project_name': data['wandb_project_name'],
-                'wandb_run_name': data['wandb_run_name']
-            },
-            'system_prompt': data['system_prompt'],
-            'tokenizer': {
-                'huggingface_tokenizer': data['huggingface_tokenizer'],
-                'tokenizer_checkpoint_path': data['tokenizer_checkpoint_path']
-            },
-            'padding': {
-                'ignore_index': data['ignore_index']
-            },
-            'distillation_config': {
-                'is_model_distillation': data['is_model_distillation'],
-                'distillation_temperature': data['distillation_temperature'],
-                'teacher_model_checkpoint': data['teacher_model_checkpoint']
-            },
-            'dpo_config': {
-                'dpo_beta': data['dpo_beta']
-            },
-            'lora': {
-                'lora_enabled': data['lora_enabled'],
-                'lora_rank': data['lora_rank'],
-                'lora_alpha': data['lora_alpha'],
-                'lora_dropout': data['lora_dropout'],
-                'lora_target_modules': data['lora_target_modules']
-            },
-            'optimizers_config': {
-                'adamw': {
-                    'adamw_min_lr': data['adamw_min_lr'],
-                    'adamw_max_lr': data['adamw_max_lr'],
-                    'adamw_weight_decay': data['adamw_weight_decay'],
-                    'adamw_betas': data['adamw_betas'],
-                    'adamw_use_fused': data['adamw_use_fused'],
-                    'adamw_warmup_steps': data['adamw_warmup_steps']
-                },
-                'muon': {
-                    'use_muon': data['use_muon'],
-                    'muon_min_lr': data['muon_min_lr'],
-                    'muon_max_lr': data['muon_max_lr'],
-                    'muon_weight_decay': data['muon_weight_decay'],
-                    'muon_momentum': data['muon_momentum'],
-                    'muon_warmup_steps': data['muon_warmup_steps']
-                }
-            },
-            'training_config': {
-                'seed': data['seed'],
-                'training_stage': data['training_stage'].value,
-                'device_type': data['device_type'].value,
-                'training_precision': data['training_precision'].value,
-                'total_batch_size': data['total_batch_size'],
-                'max_steps': data['max_steps'],
-                'early_stopping_patience': data['early_stopping_patience'],
-                'early_stopping_patience_skip_steps': data['early_stopping_patience_skip_steps']
-            },
-            'validation_config': {
-                'validate_every_x_steps': data['validate_every_x_steps'],
-                'validation_steps': data['validation_steps']
-            },
-            'eval_config': {
-                'hellaswag_every_x_steps': data['hellaswag_every_x_steps'],
-                'hellaswag_number_of_examples': data['hellaswag_number_of_examples'],
-                'winogrande_every_x_steps': data['winogrande_every_x_steps'],
-                'winogrande_number_of_examples': data['winogrande_number_of_examples'],
-                'arc_challenge_every_x_steps': data['arc_challenge_every_x_steps'],
-                'arc_challenge_number_of_examples': data['arc_challenge_number_of_examples']
-            },
-            'generation_config': {
-                'generate_every_x_steps': data['generate_every_x_steps'],
-                'max_test_gen_len': data['max_test_gen_len']
-            },
-            'derived': {
-                'is_pretraining': data['is_pretraining'],
-                'is_instruct_training': data['is_instruct_training'],
-                'is_dpo_training': data['is_dpo_training'],
-                'dataloader_root_path': data['dataloader_root_path'],
-                'save_checkpoints_path': data['save_checkpoints_path']
-            }
-        }
-        if include_model_config is True:
-            summary['model_config'] = {
-                'dim': data['dim'],
-                'n_layers': data['n_layers'],
-                'n_heads': data['n_heads'],
-                'n_kv_heads': data['n_kv_heads'],
-                'multiple_of': data['multiple_of'],
-                'ffn_dim_multiplier': data['ffn_dim_multiplier'],
-                'norm_eps': data['norm_eps'],
-                'is_rope_cis': data['is_rope_cis'],
-                'rope_theta': data['rope_theta'],
-                'max_batch_size': data['max_batch_size'],
-                'max_seq_len': data['max_seq_len'],
-                'is_moe': data['is_moe'],
-                'moe_num_experts': data['moe_num_experts'],
-                'moe_expert_dim': data['moe_expert_dim'],
-                'moe_top_k': data['moe_top_k'],
-                'moe_load_balancing_coef': data['moe_load_balancing_coef'],
-                'moe_z_loss_coef': data['moe_z_loss_coef'],
-                'moe_compute_stats': data['moe_compute_stats']
-            }
-        return summary
-
-    model_config = ConfigDict(
-        env_file = '.env',
-        extra = 'ignore'
-    )
-
-config = TrainConfig()
+config = GlobalConfig()

--- a/config.py
+++ b/config.py
@@ -71,7 +71,7 @@ class PromptConfig(BaseModel):
 
 class TrainingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    stage: TrainingStage = TrainingStage.DPO
+    stage: TrainingStage = TrainingStage.PRETRAINING
     seed: int = 42
     total_batch_size: int = 524288
     max_steps: int = 200
@@ -80,7 +80,7 @@ class TrainingConfig(BaseModel):
 
 class EvalTaskConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    every_x_steps: int = -1
+    every_x_steps: int = 1
     number_of_examples: int = 200
 
 class EvalsConfig(BaseModel):

--- a/dataloaders.py
+++ b/dataloaders.py
@@ -22,7 +22,7 @@ def load_tokens(filename):
     ptt = torch.from_numpy(npt)
     return ptt
 
-class PretrainDataLoader:
+class PretrainingDataLoader:
     def __init__(self, batch_size, sequence_length, is_master_process, process_rank, num_processes, data_root, split, use_shuffle=False):
         self.B = batch_size
         self.S = sequence_length
@@ -175,7 +175,7 @@ class InstructDataLoader:
             labels = pad_sequence(
                 labels,
                 batch_first=True,
-                padding_value=config.ignore_index
+                padding_value=config.tokenizer.ignore_index
             )
             if ids.size(1) > sequence_length:
                 ids  = ids[:, -sequence_length:]
@@ -218,7 +218,7 @@ class InstructDataLoader:
         def _calculate():
             return sum(self._dataloader.dataset.map(
                 lambda ex: {'len': len(ex['input_ids'])},
-                num_proc=config.number_of_cpu_processes,
+                num_proc=config.runtime.number_of_cpu_processes,
                 remove_columns=[],
                 desc='Calculating number of tokens'
             )['len'])
@@ -338,7 +338,7 @@ class DirectPreferenceOptimizationDataLoader:
         def _calculate():
             return sum(self._dataloader.dataset.map(
                 lambda ex: {'len': len(ex['prompt_input_ids']) + len(ex['chosen_input_ids']) + len(ex['rejected_input_ids'])},
-                num_proc=config.number_of_cpu_processes,
+                num_proc=config.runtime.number_of_cpu_processes,
                 remove_columns=[],
                 desc='Calculating number of tokens'
             )['len'])
@@ -378,12 +378,12 @@ def init_data_loaders(
     training_stage,
     pad_id=None
 ):
-    if training_stage == TrainingStage.PRETRAIN:
+    if training_stage == TrainingStage.PRETRAINING:
         if is_master_process:
-            print('\nPretrain Data Loaders:')
+            print('\nPretraining Data Loaders:')
             print('----------------------------------------')
 
-        train_loader = PretrainDataLoader(
+        train_loader = PretrainingDataLoader(
             batch_size=batch_size,
             sequence_length=sequence_length,
             is_master_process=is_master_process,
@@ -393,7 +393,7 @@ def init_data_loaders(
             split='train',
             use_shuffle=True
         )
-        val_loader = PretrainDataLoader(
+        val_loader = PretrainingDataLoader(
             batch_size=batch_size,
             sequence_length=sequence_length,
             is_master_process=is_master_process,

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -20,8 +20,8 @@ def stable_hash(text, *, seed=None, hash_bytes=8):
 
 def get_max_number_of_cpu_processes():
     NUMBER_OF_PROCESSES = max(1, os.cpu_count() // 2)
-    if config.number_of_cpu_processes != 0:
-        NUMBER_OF_PROCESSES = max(1, min(config.number_of_cpu_processes, os.cpu_count()))
+    if config.runtime.number_of_cpu_processes != 0:
+        NUMBER_OF_PROCESSES = max(1, min(config.runtime.number_of_cpu_processes, os.cpu_count()))
     print(f'Number of CPU processes: {NUMBER_OF_PROCESSES}\n')
     return NUMBER_OF_PROCESSES
 

--- a/datasets_preparation/prepare_arc_challenge_dataset.py
+++ b/datasets_preparation/prepare_arc_challenge_dataset.py
@@ -15,11 +15,11 @@ def prepare_arc_challenge_dataset():
 
     current_dir = Path(__file__).resolve().parent.parent
 
-    data_cache_dir = current_dir / config.arc_challenge_path
+    data_cache_dir = current_dir / config.paths.evals.arc_challenge_path
     data_cache_dir.mkdir(parents=True, exist_ok=True)
     data_filename = data_cache_dir / 'arc_challenge_val.jsonl'
 
-    tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+    tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
 
     def prepare_example(example):
         """
@@ -84,7 +84,7 @@ def prepare_arc_challenge_dataset():
             name='ARC-Challenge',
             split='validation',
             num_proc=number_of_processes,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         with open(data_filename, 'w', encoding='utf-8') as file:

--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -79,9 +79,9 @@ ASSIST = None
 def tokenize(doc):
     global tokenizer, SYS, SYS_PROMPT, NL, ASSIST
     if tokenizer is None:
-        tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+        tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
         SYS = tokenizer.encode('system')
-        SYS_PROMPT = tokenizer.encode('\n' + config.system_prompt)
+        SYS_PROMPT = tokenizer.encode('\n' + config.prompts.system_prompt)
         NL = tokenizer.encode('\n')
         ASSIST = tokenizer.encode('assistant')
 
@@ -161,7 +161,7 @@ def download_and_prepare_data(
             name=hf_name,
             split=split,
             num_proc=number_of_processes,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         if max_datapoints:
@@ -171,7 +171,7 @@ def download_and_prepare_data(
         def normalize(doc):
             data = adapter(doc, transforms)
             data['prompt'] = ensure_user_first(data['prompt'])
-            if config.hf_include_source_id:
+            if config.data_preparation.hf_include_source_id:
                 data.update({'source': ds_id})
 
             return data
@@ -206,8 +206,8 @@ def download_and_prepare_data(
 
     print('- Train len:', len(splits['train']), ' Val len:', len(splits['test']), '\n')
 
-    splits['train'].save_to_disk(os.path.join(config.dpo_dataset_target_path, 'train'))
-    splits['test'] .save_to_disk(os.path.join(config.dpo_dataset_target_path, 'val'))
+    splits['train'].save_to_disk(os.path.join(config.paths.datasets.dpo_path, 'train'))
+    splits['test'] .save_to_disk(os.path.join(config.paths.datasets.dpo_path, 'val'))
 
 
 def prepare_dpo_dataset(

--- a/datasets_preparation/prepare_hellaswag_dataset.py
+++ b/datasets_preparation/prepare_hellaswag_dataset.py
@@ -15,11 +15,11 @@ def prepare_hellaswag_dataset():
 
     current_dir = Path(__file__).resolve().parent.parent
 
-    data_cache_dir = current_dir / config.hellaswag_path
+    data_cache_dir = current_dir / config.paths.evals.hellaswag_path
     data_cache_dir.mkdir(parents=True, exist_ok=True)
     data_filename = data_cache_dir / 'hellaswag_val.jsonl'
 
-    tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+    tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
 
     def prepare_example(example):
         """
@@ -78,7 +78,7 @@ def prepare_hellaswag_dataset():
             'Rowan/hellaswag',
             split='validation',
             num_proc=number_of_processes,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         with open(data_filename, 'w', encoding='utf-8') as file:

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -99,9 +99,9 @@ NL = None
 def tokenize(doc):
     global tokenizer, SYS, SYS_PROMPT, NL
     if tokenizer is None:
-        tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+        tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
         SYS = tokenizer.encode('system')
-        SYS_PROMPT = tokenizer.encode('\n' + config.system_prompt)
+        SYS_PROMPT = tokenizer.encode('\n' + config.prompts.system_prompt)
         NL = tokenizer.encode('\n')
 
     bot = tokenizer.bos_id
@@ -115,7 +115,7 @@ def tokenize(doc):
         if is_assistant:
             labels.extend(tok_ids)
         else:
-            labels.extend([config.ignore_index] * len(tok_ids))
+            labels.extend([config.tokenizer.ignore_index] * len(tok_ids))
 
     push([bot], False)
     push([sh], False)
@@ -136,7 +136,7 @@ def tokenize(doc):
         push([eot], role == 'assistant')
 
     input_ids = np.array(tokens, dtype=np.uint32)
-    labels = np.array(labels[1:] + [config.ignore_index], dtype=np.int32)
+    labels = np.array(labels[1:] + [config.tokenizer.ignore_index], dtype=np.int32)
 
     return { 'input_ids': input_ids, 'labels': labels }
 
@@ -168,7 +168,7 @@ def download_and_prepare_data(
             name=hf_name,
             split=split,
             num_proc=number_of_processes,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         if max_datapoints:
@@ -181,7 +181,7 @@ def download_and_prepare_data(
             conversation = conversation[:max_turns]
 
             result = {'conversation': []}
-            if config.hf_include_source_id:
+            if config.data_preparation.hf_include_source_id:
                 result['source'] = ds_id
 
             if not has_assistant_content(conversation):
@@ -220,8 +220,8 @@ def download_and_prepare_data(
 
     print('- Train len:', len(splits['train']), ' Val len:', len(splits['test']), '\n')
 
-    splits['train'].save_to_disk(os.path.join(config.instruct_dataset_target_path, 'train'))
-    splits['test'] .save_to_disk(os.path.join(config.instruct_dataset_target_path, 'val'))
+    splits['train'].save_to_disk(os.path.join(config.paths.datasets.instruct_path, 'train'))
+    splits['test'] .save_to_disk(os.path.join(config.paths.datasets.instruct_path, 'val'))
 
 def prepare_instruct_dataset(
     *,

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -74,7 +74,7 @@ def download_and_prepare_data(
             name=hf_name,
             split=split,
             streaming=True,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         columns_to_remove = ds.column_names
@@ -95,7 +95,7 @@ def download_and_prepare_data(
             batch = adapter(batch, transforms)
             texts = batch['text']
 
-            if config.hf_include_source_id:
+            if config.data_preparation.hf_include_source_id:
                 return {
                     'text': texts,
                     'source': [ds_id] * len(texts),
@@ -106,7 +106,7 @@ def download_and_prepare_data(
         ds = ds.map(
             normalize,
             batched=True,
-            batch_size=config.hf_map_batch_size,
+            batch_size=config.data_preparation.hf_map_batch_size,
             remove_columns=columns_to_remove
         )
 
@@ -148,7 +148,7 @@ tokenizer = None
 def tokenize(doc):
     global tokenizer
     if tokenizer is None:
-        tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+        tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
     input_ids = tokenizer.encode(doc['text'])
     tokens_np = np.empty(len(input_ids) + 1, dtype=np.uint32)
     tokens_np[0] = tokenizer.eos_id
@@ -166,22 +166,22 @@ def shard_and_tokenize(
     prepare_dataset(
         dataset=train_ds,
         tokenize_function=tokenize,
-        target_folder=os.path.join(config.pretrain_dataset_target_path, 'train'),
+        target_folder=os.path.join(config.paths.datasets.pretraining_path, 'train'),
         shard_file_prefix='data',
         shard_size=shard_size,
         number_of_processes=number_of_processes,
-        chunksize=config.mp_pool_chunk_size
+        chunksize=config.data_preparation.mp_pool_chunk_size
     )
 
     print('Preparing val dataset...')
     prepare_dataset(
         dataset=val_ds,
         tokenize_function=tokenize,
-        target_folder=os.path.join(config.pretrain_dataset_target_path, 'val'),
+        target_folder=os.path.join(config.paths.datasets.pretraining_path, 'val'),
         shard_file_prefix='data',
         shard_size=shard_size,
         number_of_processes=number_of_processes,
-        chunksize=config.mp_pool_chunk_size
+        chunksize=config.data_preparation.mp_pool_chunk_size
     )
 
 def prepare_pretraining_dataset(

--- a/datasets_preparation/prepare_winogrande_dataset.py
+++ b/datasets_preparation/prepare_winogrande_dataset.py
@@ -15,11 +15,11 @@ def prepare_winogrande_dataset():
 
     current_dir = Path(__file__).resolve().parent.parent
 
-    data_cache_dir = current_dir / config.winogrande_path
+    data_cache_dir = current_dir / config.paths.evals.winogrande_path
     data_cache_dir.mkdir(parents=True, exist_ok=True)
     data_filename = data_cache_dir / 'winogrande_val.jsonl'
 
-    tokenizer = init_tokenizer(config.tokenizer_checkpoint_path, config.huggingface_tokenizer)
+    tokenizer = init_tokenizer(config.tokenizer.checkpoint_path, config.tokenizer.huggingface_tokenizer)
 
     def prepare_example(example):
         """
@@ -78,7 +78,7 @@ def prepare_winogrande_dataset():
             name='winogrande_debiased',
             split='validation',
             num_proc=number_of_processes,
-            token=config.hf_token
+            token=config.third_party.hf_token
         )
 
         with open(data_filename, 'w', encoding='utf-8') as file:

--- a/engine/core.py
+++ b/engine/core.py
@@ -1,3 +1,5 @@
+import math
+
 from dataclasses import dataclass
 
 
@@ -11,3 +13,15 @@ class TrainerState:
     num_val_runs_no_improve: int = 0
     should_stop: bool = False
     is_last_step: bool = False
+
+    def to_dict(self):
+        return {
+            'start_step': self.start_step,
+            'current_step': self.current_step,
+            'max_steps': self.max_steps,
+            'best_val_loss': self.best_val_loss if not math.isinf(self.best_val_loss) else None,
+            'last_val_loss': self.last_val_loss if not math.isinf(self.last_val_loss) else None,
+            'num_val_runs_no_improve': self.num_val_runs_no_improve,
+            'should_stop': self.should_stop,
+            'is_last_step': self.is_last_step
+        }

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -24,12 +24,12 @@ def prepare_workload_summary(
     model_trainable_params_count: int,
     total_tokens: int
 ):
-    if config.training_stage == TrainingStage.PRETRAIN or config.training_stage == TrainingStage.INSTRUCT:
+    if config.training.stage == TrainingStage.PRETRAINING or config.training.stage == TrainingStage.INSTRUCT:
         # For pretraining according to the Chinchilla paper ~20.0 is reasonable. For instruct: ~0.2 to ~0.5 is reasonable
-        m_factor = 20.0 if config.training_stage == TrainingStage.PRETRAIN else 0.3
+        m_factor = 20.0 if config.training.stage == TrainingStage.PRETRAINING else 0.3
         tokens_required_for_model_size = int(model_params_count * m_factor)
-        steps_needed = math.ceil(tokens_required_for_model_size / config.total_batch_size)
-        tokens_per_step = config.total_batch_size
+        steps_needed = math.ceil(tokens_required_for_model_size / config.training.total_batch_size)
+        tokens_per_step = config.training.total_batch_size
         tokens_coverage = trainer_state.max_steps * tokens_per_step
         dataset_fraction = tokens_coverage / total_tokens if total_tokens > 0 else None
 
@@ -54,12 +54,12 @@ def prepare_workload_summary(
         }
 
     summary = {
-        'config': config.to_summary_dict(include_model_config=False),
-        'model_config': model_config.to_dict(),
+        'config': config.model_dump(),
         'checkpoint_data': checkpoint_data.to_dict() if checkpoint_data else None,
         'trainer_ctx': trainer_ctx.to_dict(),
         'optimizer_plan': optimizer_plan.to_dict(),
-        'derived_properties': derived
+        'derived_properties': derived,
+        'trainer_state': trainer_state.to_dict()
     }
 
     return summary

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -1,7 +1,6 @@
 import math
 
-from config import TrainingStage, TrainConfig
-from model import ModelConfig
+from config import TrainingStage, GlobalConfig
 from checkpoints import CheckpointData
 from engine.context import TrainerContext
 from engine.optim import OptimizerPlan
@@ -16,8 +15,7 @@ from logger import logger
 
 def prepare_workload_summary(
     *,
-    config: TrainConfig,
-    model_config: ModelConfig,
+    config: GlobalConfig,
     checkpoint_data: CheckpointData,
     trainer_ctx: TrainerContext,
     optimizer_plan: OptimizerPlan,

--- a/engine/optim.py
+++ b/engine/optim.py
@@ -1,5 +1,6 @@
 import torch
 import re
+import json
 
 from torch.optim import AdamW, Muon
 from dataclasses import dataclass, field
@@ -198,10 +199,10 @@ def build_adamw_groups(config, parameter_buckets: ParameterBuckets) -> list[Para
             adamw_groups.append(group)
 
     _add(extract_group(optimizer_kind='adamw', group_name='adapter', named_params=parameter_buckets.adapter, weight_decay=0.0))
-    _add(extract_group(optimizer_kind='adamw', group_name='embedding', named_params=parameter_buckets.embedding, weight_decay=config.adamw_weight_decay))
-    _add(extract_group(optimizer_kind='adamw', group_name='output', named_params=parameter_buckets.output, weight_decay=config.adamw_weight_decay))
-    if not config.use_muon:
-        _add(extract_group(optimizer_kind='adamw', group_name='matrix', named_params=parameter_buckets.matrix, weight_decay=config.adamw_weight_decay))
+    _add(extract_group(optimizer_kind='adamw', group_name='embedding', named_params=parameter_buckets.embedding, weight_decay=config.optimizers.adamw.weight_decay))
+    _add(extract_group(optimizer_kind='adamw', group_name='output', named_params=parameter_buckets.output, weight_decay=config.optimizers.adamw.weight_decay))
+    if not config.optimizers.muon.enabled:
+        _add(extract_group(optimizer_kind='adamw', group_name='matrix', named_params=parameter_buckets.matrix, weight_decay=config.optimizers.adamw.weight_decay))
     _add(extract_group(optimizer_kind='adamw', group_name='scalar', named_params=parameter_buckets.scalar, weight_decay=0.0))
 
     return adamw_groups
@@ -213,27 +214,27 @@ def build_muon_groups(config, parameter_buckets: ParameterBuckets) -> list[Param
         if group is not None:
             muon_groups.append(group)
 
-    _add(extract_group(optimizer_kind='muon', group_name='matrix', named_params=parameter_buckets.matrix, weight_decay=config.muon_weight_decay))
+    _add(extract_group(optimizer_kind='muon', group_name='matrix', named_params=parameter_buckets.matrix, weight_decay=config.optimizers.muon.weight_decay))
 
     return muon_groups
 
 def build_optimizer_plan(config, parameter_buckets: ParameterBuckets) -> OptimizerPlan:
     adamw_groups = build_adamw_groups(config, parameter_buckets)
     adamw_plan = AdamWPlan(
-        lr=config.adamw_max_lr,
-        weight_decay=config.adamw_weight_decay,
-        betas=config.adamw_betas,
+        lr=config.optimizers.adamw.max_lr,
+        weight_decay=config.optimizers.adamw.weight_decay,
+        betas=config.optimizers.adamw.betas,
         groups=adamw_groups
     )
 
     muon_plan = None
-    if config.use_muon:
+    if config.optimizers.muon.enabled:
         muon_groups = build_muon_groups(config, parameter_buckets)
         if muon_groups:
             muon_plan = MuonPlan(
-                lr=config.muon_max_lr,
-                weight_decay=config.muon_weight_decay,
-                momentum=config.muon_momentum,
+                lr=config.optimizers.muon.max_lr,
+                weight_decay=config.optimizers.muon.weight_decay,
+                momentum=config.optimizers.muon.momentum,
                 groups=muon_groups
             )
         else:
@@ -265,7 +266,7 @@ def build_optimizers(config, optimizer_plan: OptimizerPlan) -> Optimizers:
             params=adamw_groups,
             lr=optimizer_plan.adamw.lr,
             betas=optimizer_plan.adamw.betas,
-            fused=config.adamw_use_fused
+            fused=config.optimizers.adamw.use_fused
         )
         logger.info('AdamW ready')
     if optimizer_plan.muon:

--- a/engine/torch_profiler.py
+++ b/engine/torch_profiler.py
@@ -17,7 +17,7 @@ class NoOpProfiler:
         pass
 
 def init_torch_profiler_context(config, distributed_ctx):
-    if not config.torch_profiler_enabled or not distributed_ctx.is_master_process:
+    if not config.torch_profiler.enabled or not distributed_ctx.is_master_process:
         return NoOpProfiler()
 
     def trace_handler(prof):
@@ -40,11 +40,11 @@ def init_torch_profiler_context(config, distributed_ctx):
             profile_memory=True,
             acc_events=True,
             schedule=schedule(
-                skip_first=config.torch_profiler_schedule_skip_first,
-                wait=config.torch_profiler_schedule_wait,
-                warmup=config.torch_profiler_schedule_warmup,
-                active=config.torch_profiler_schedule_active,
-                repeat=config.torch_profiler_schedule_repeat
+                skip_first=config.torch_profiler.schedule_skip_first,
+                wait=config.torch_profiler.schedule_wait,
+                warmup=config.torch_profiler.schedule_warmup,
+                active=config.torch_profiler.schedule_active,
+                repeat=config.torch_profiler.schedule_repeat
             ),
             on_trace_ready=trace_handler
         )

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -95,7 +95,6 @@ class Trainer:
         self.arc_challenge_data = None
         self.test_generation_prompts = None
         self.tokenizer = None
-        self.model_config = None
         self.model = None
         self.train_loader = None
         self.val_loader = None
@@ -182,7 +181,7 @@ class Trainer:
             self.restore_data_loaders_state()
 
     def build_task(self):
-        self.task = get_task(self.config.training_stage)
+        self.task = get_task(self.config.training.stage)
         self.task.setup(config=self.config, ctx=self.trainer_ctx)
         self.task_assets = self.task.build_assets(tokenizer=self.tokenizer, model=self.model)
 
@@ -222,7 +221,7 @@ class Trainer:
                     reduce_dtype=torch.float32
                 ) if self.config.runtime.use_fsdp else None
             )
-        elif self.config.training_precision == TrainingPrecision.FP16:
+        elif self.config.runtime.training_precision == TrainingPrecision.FP16:
             self.precision_ctx = PrecisionContext(
                 use_autocast=True,
                 scaler=torch.amp.GradScaler(self.device_ctx.device_type), # need gradscaler when fp16
@@ -231,9 +230,9 @@ class Trainer:
                 fsdp_mp=MixedPrecisionPolicy(
                     param_dtype=torch.float16,
                     reduce_dtype=torch.float32
-                ) if self.config.use_fsdp else None
+                ) if self.config.runtime.use_fsdp else None
             )
-        elif self.config.training_precision == TrainingPrecision.FP32:
+        elif self.config.runtime.training_precision == TrainingPrecision.FP32:
             self.precision_ctx = PrecisionContext(
                 use_autocast=False,
                 scaler=None,
@@ -278,7 +277,7 @@ class Trainer:
         self.test_generation_prompts = test_prompts_data[stage]
 
     def load_hellaswag_eval_data(self):
-        if self.config.evals.hellaswag.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
+        if self.config.evals.hellaswag.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.hellaswag_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.hellaswag_path}/hellaswag_val.jsonl',
@@ -288,7 +287,7 @@ class Trainer:
         )
 
     def load_winogrande_eval_data(self):
-        if self.config.evals.winogrande.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
+        if self.config.evals.winogrande.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.winogrande_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.winogrande_path}/winogrande_val.jsonl',
@@ -298,7 +297,7 @@ class Trainer:
         )
 
     def load_arc_challenge_eval_data(self):
-        if self.config.evals.arc_challenge.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
+        if self.config.evals.arc_challenge.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.arc_challenge_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.arc_challenge_path}/arc_challenge_val.jsonl',
@@ -315,13 +314,14 @@ class Trainer:
 
     def build_model(self):
         self.model = Transformer(
-            self.config.model,
-            self.tokenizer,
-            self.config.tokenizer.ignore_index
+            config=self.config.model,
+            pad_token_id=self.tokenizer.pad_id,
+            vocab_size=self.tokenizer.vocab_size,
+            ignore_index=self.config.tokenizer.ignore_index
         )
 
     def is_pretraining(self):
-        return self.config.training.stage == TrainingStage.PRETRAIN
+        return self.config.training.stage == TrainingStage.PRETRAINING
 
     def is_instruct(self):
         return self.config.training.stage == TrainingStage.INSTRUCT
@@ -332,11 +332,11 @@ class Trainer:
     def get_dataloader_root_path(self):
         dataloaders_paths = self.config.paths.dataloaders
         if self.is_pretraining():
-            return dataloaders_paths.pretrain_root_path
-        elif is_instruct():
+            return dataloaders_paths.pretraining_root_path
+        elif self.is_instruct():
             return dataloaders_paths.instruct_root_path
-        elif is_dpo():
-            return dataloaders_paths.dpo
+        elif self.is_dpo():
+            return dataloaders_paths.dpo_root_path
         else:
             raise ValueError('No valid dataloader root path')
 
@@ -356,7 +356,7 @@ class Trainer:
         args = self.args
 
         selected = [
-            bool(args.pretrain_checkpoint),
+            bool(args.pretraining_checkpoint),
             bool(args.instruct_checkpoint),
             bool(args.dpo_checkpoint),
         ]
@@ -368,9 +368,9 @@ class Trainer:
 
         path = None
         name = None
-        if args.pretrain_checkpoint:
-            path = self.config.pretrain_load_checkpoints_path
-            name = args.pretrain_checkpoint
+        if args.pretraining_checkpoint:
+            path = self.config.pretraining_load_checkpoints_path
+            name = args.pretraining_checkpoint
         elif args.instruct_checkpoint:
             path = self.config.instruct_load_checkpoints_path
             name = args.instruct_checkpoint
@@ -436,10 +436,10 @@ class Trainer:
         config = self.config
         apply_lora(
             self.model,
-            rank=config.lora_rank,
-            alpha=config.lora_alpha,
-            dropout=config.lora_dropout,
-            target_modules=config.lora_target_modules,
+            rank=config.lora.rank,
+            alpha=config.lora.alpha,
+            dropout=config.lora.dropout,
+            target_modules=config.lora.target_modules,
             is_master_process=self.distributed_ctx.is_master_process
         )
         # by default we freeze the other parameters
@@ -453,7 +453,7 @@ class Trainer:
 
     def resolve_apply_lora(self):
         if (
-            self.config.lora_enabled and
+            self.config.lora.enabled and
             (
                 (not self.checkpoint_data) or
                 (self.checkpoint_data and not self.checkpoint_data.is_lora_checkpoint)
@@ -474,7 +474,7 @@ class Trainer:
             self.val_loader.load_state_dict(checkpoint_data.val_loader_state)
 
     def compile_model(self):
-        if self.config.use_torch_compile:
+        if self.config.runtime.use_torch_compile:
             self.model.compile()
 
     def prepare_model_for_distributed_context(self):
@@ -483,11 +483,11 @@ class Trainer:
         fsdp_mp = self.precision_ctx.fsdp_mp
         model_dtype = self.precision_ctx.model_dtype
 
-        if self.config.use_fsdp:
+        if self.config.runtime.use_fsdp:
             if not dist.is_initialized():
-                raise ValueError('dist must be initialized if "USE_FSDP" flag is set.')
-            if self.config.use_torch_compile:
-                raise ValueError('Currently not supporting torch compile for FSDP. Please set "USE_TORCH_COMPILE" flag to False.')
+                raise ValueError('dist must be initialized if "config.runtime.use_fsdp" flag is set. Run with `torchrun` to force `dist` to initialize.')
+            if self.config.runtime.use_torch_compile:
+                raise ValueError('Currently not supporting torch compile for FSDP. Please set "config.runtime.use_torch_compile" flag to False.')
             logger.info('\nFSDP')
             logger.info('----------------------------------------')
             logger.info('Wrapping the model in preparation for FSDP')
@@ -526,9 +526,9 @@ class Trainer:
             logger.info('Muon optimizer state loaded and ready')
 
     def prepare_runtime(self):
-        self.trainer_state.max_steps = self.config.max_steps
+        self.trainer_state.max_steps = self.config.training.max_steps
         if self.trainer_state.max_steps <= 0:
-            self.trainer_state.max_steps = math.ceil(self.train_loader.calculate_max_tokens() / self.config.total_batch_size)
+            self.trainer_state.max_steps = math.ceil(self.train_loader.calculate_max_tokens() / self.config.training.total_batch_size)
         if self.checkpoint_data:
             self.trainer_state.start_step = self.checkpoint_data.resume_step if self.args.start_step is None else self.args.start_step
             self.trainer_state.current_step = self.checkpoint_data.resume_step if self.args.start_step is None else self.args.start_step
@@ -543,7 +543,6 @@ class Trainer:
         if self.distributed_ctx.is_master_process:
             self.workload_summary = prepare_workload_summary(
                 config=self.config,
-                model_config=self.model_config,
                 checkpoint_data=self.checkpoint_data,
                 trainer_ctx=self.trainer_ctx,
                 optimizer_plan=self.optimizer_plan,
@@ -555,19 +554,19 @@ class Trainer:
 
     def log_workload_summary(self):
         if self.distributed_ctx.is_master_process:
-            logger.info(f'\n{self.config.training_stage.value.upper()} WORKLOAD SUMMARY:')
+            logger.info(f'\n{self.config.training.stage.value.upper()} WORKLOAD SUMMARY:')
             logger.info('--------------------------------------------------------')
             logger.info(self.workload_summary, is_json=True)
             logger.info('--------------------------------------------------------')
 
     def setup_wandb(self):
         self.wandb = WandbWrapper(
-            enabled=self.config.wandb_enabled,
+            enabled=self.config.wandb.enabled,
             is_master_process=self.distributed_ctx.is_master_process
         )
         self.wandb.init(
-            self.config.wandb_project_name,
-            job_name=self.config.wandb_run_name,
+            self.config.wandb.project_name,
+            job_name=self.config.wandb.run_name,
             config=self.workload_summary
         )
 
@@ -625,12 +624,16 @@ class Trainer:
             logger.info(log, pbar=pbar)
         self.wandb.log(wanb_log)
 
-    def should_run(self, step, every, last_step, run_last_step=True):
+    def should_run(self, step, every, last_step, run_last_step=True, force_first_step=False):
         if every == -1:
             return run_last_step and last_step
         if every <= 0:
             return False
-        return (step > 0 and step % every == 0) or (run_last_step and last_step)
+        return (
+            (step > 0 and step % every == 0) or
+            (run_last_step and last_step) or
+            (force_first_step and every != -1 and step == 0)
+        )
 
     def clip_grad_norm(self, model, max_norm):
         norm = clip_grad_norm_(model.parameters(), max_norm)
@@ -657,10 +660,10 @@ class Trainer:
         if self.optimizers.adamw:
             adamw_lr = cosine_scheduler(
                 step=step,
-                warmup_steps=self.config.adamw_warmup_steps,
+                warmup_steps=self.config.optimizers.adamw.warmup_steps,
                 max_steps=self.trainer_state.max_steps,
-                max_lr=self.config.adamw_max_lr,
-                min_lr=self.config.adamw_min_lr,
+                max_lr=self.config.optimizers.adamw.max_lr,
+                min_lr=self.config.optimizers.adamw.min_lr,
             )
             for group in self.optimizers.adamw.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)
@@ -669,10 +672,10 @@ class Trainer:
         if self.optimizers.muon:
             muon_lr = cosine_scheduler(
                 step=step,
-                warmup_steps=self.config.muon_warmup_steps,
+                warmup_steps=self.config.optimizers.muon.warmup_steps,
                 max_steps=self.trainer_state.max_steps,
-                max_lr=self.config.muon_max_lr,
-                min_lr=self.config.muon_min_lr,
+                max_lr=self.config.optimizers.muon.max_lr,
+                min_lr=self.config.optimizers.muon.min_lr,
             )
             for group in self.optimizers.muon.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)
@@ -776,13 +779,13 @@ class Trainer:
         )
 
     def prepare_moe_metrics(self):
-        if self.config.is_moe and self.config.moe_compute_stats:
+        if self.config.model.moe.enabled and self.config.model.moe.compute_stats:
             get_model(self.model).enable_moe_stats()
             get_model(self.model).reset_moe_stats()
 
     def get_moe_metrics(self):
         moe_metrics = {}
-        if self.config.is_moe and self.config.moe_compute_stats:
+        if self.config.model.moe.enabled and self.config.model.moe.compute_stats:
             moe_metrics = collect_moe_metrics(
                 get_model(self.model),
                 self.trainer_ctx.distributed.ddp,
@@ -796,8 +799,8 @@ class Trainer:
         ddp = self.trainer_ctx.distributed.ddp
         device = self.trainer_ctx.device.device
         is_master_process = self.trainer_ctx.distributed.is_master_process
-        early_stopping_patience = self.config.early_stopping_patience
-        early_stopping_patience_skip_steps = self.config.early_stopping_patience_skip_steps + self.trainer_state.start_step
+        early_stopping_patience = self.config.training.early_stopping_patience
+        early_stopping_patience_skip_steps = self.config.training.early_stopping_patience_skip_steps + self.trainer_state.start_step
 
         loss_sum = torch.tensor(0.0, device=device)
         tokens_sum = torch.tensor(0.0, device=device)
@@ -808,7 +811,7 @@ class Trainer:
         self.model.eval()
         self.prepare_moe_metrics()
 
-        for _ in tqdm(range(self.config.validation_steps), 'Validating', disable=not is_master_process, leave=False):
+        for _ in tqdm(range(self.config.validation.validation_steps), 'Validating', disable=not is_master_process, leave=False):
             output = self.task.validation_step(self.model, self.val_loader.next_batch(), self.task_assets)
             loss = output.loss
             n_valid = output.n_valid
@@ -863,10 +866,21 @@ class Trainer:
             pbar=pbar
         )
 
+    def get_save_checkpoints_path(self):
+        checkpoints_paths = self.config.paths.checkpoints
+        if self.is_pretraining():
+            return checkpoints_paths.pretraining_save_path
+        elif self.is_instruct():
+            return checkpoints_paths.instruct_save_path
+        elif self.is_dpo():
+            return checkpoints_paths.dpo_save_path
+        else:
+            raise ValueError('No valid checkpointing path')
+
     def run_save_checkpoint(self, pbar=None):
         if (
-            not self.config.save_checkpoints or
-            (self.config.save_best_only and self.trainer_state.num_val_runs_no_improve > 0)
+            not self.config.checkpointing.save_checkpoints or
+            (self.config.checkpointing.save_best_only and self.trainer_state.num_val_runs_no_improve > 0)
         ):
             return
 
@@ -878,9 +892,8 @@ class Trainer:
 
         logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
         save_checkpoint(
-            self.config.save_checkpoints_path,
+            self.get_save_checkpoints_path(),
             get_model(self.model),
-            self.model_config,
             self.config,
             self.trainer_state.current_step,
             self.trainer_state.last_val_loss,
@@ -889,18 +902,18 @@ class Trainer:
             self.train_loader,
             self.val_loader,
             {
-                'training_stage': self.config.training_stage.value,
-                'lora_enabled': self.config.lora_enabled,
+                'training_stage': self.config.training.stage.value,
+                'lora_enabled': self.config.lora.enabled,
                 'ddp_world_size': self.distributed_ctx.ddp_world_size
             },
-            self.config.max_number_checkpoints,
+            self.config.checkpointing.max_number_checkpoints,
             self.distributed_ctx.is_master_process,
             pbar=pbar
         )
 
     @torch.inference_mode()
     def run_multiple_choice_eval(self, *, pbar, data, tqdm_label: str, step_type: StepType):
-        if not self.config.is_pretraining:
+        if not self.is_pretraining():
             return
         ddp = self.trainer_ctx.distributed.ddp
         is_master_process = self.trainer_ctx.distributed.is_master_process
@@ -976,22 +989,33 @@ class Trainer:
 
     @torch.inference_mode()
     def run_generation(self, pbar):
+        self.model.eval()
+        outputs = None
+        with torch.autocast(
+            device_type=self.trainer_ctx.device.device_type,
+            dtype=self.trainer_ctx.precision.autocast_dtype,
+            enabled=self.trainer_ctx.precision.use_autocast
+        ):
+            outputs = generate_and_decode(
+                texts=self.test_generation_prompts,
+                model=get_model(self.model),
+                tokenizer=self.tokenizer,
+                max_gen_len=self.config.generation.max_test_gen_len,
+                full_seq=True,
+                device=self.trainer_ctx.device.device,
+                dtype=self.trainer_ctx.precision.autocast_dtype,
+                is_instruct=self.is_instruct(),
+                temperature=0.0,
+                top_p=1.0,
+                use_kv_cache=True
+            )
+
         if not self.trainer_ctx.distributed.is_master_process:
             return
-        self.model.eval()
+
         logger.info(f'{self.trainer_state.current_step:4d} | Generation testing:', pbar=pbar)
         logger.info('-----------------------------------------------', pbar=pbar)
-        for text in generate_and_decode(
-            model=get_model(self.model),
-            texts=self.test_generation_prompts,
-            max_gen_len=self.config.max_test_gen_len,
-            full_seq=True,
-            device=self.trainer_ctx.device.device,
-            is_instruct=self.config.is_instruct_training,
-            temperature=0.0,
-            top_p=1.0,
-            use_kv_cache=True
-        ):
+        for text in outputs:
             logger.info(text, pbar=pbar)
         logger.info('-----------------------------------------------', pbar=pbar)
 
@@ -1000,17 +1024,17 @@ class Trainer:
         is_last_step = self.trainer_state.is_last_step
 
         self.run_train(pbar)
-        if self.should_run(step, self.config.validate_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.validation.validate_every_x_steps, is_last_step, force_first_step=True):
             self.run_validation(pbar)
-        if self.should_run(step, self.config.save_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.checkpointing.save_every_x_steps, is_last_step):
             self.run_save_checkpoint(pbar)
-        if self.should_run(step, self.config.hellaswag_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.evals.hellaswag.every_x_steps, is_last_step):
             self.run_hellaswag_eval(pbar)
-        if self.should_run(step, self.config.winogrande_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.evals.winogrande.every_x_steps, is_last_step):
             self.run_winogrande_eval(pbar)
-        if self.should_run(step, self.config.arc_challenge_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.evals.arc_challenge.every_x_steps, is_last_step):
             self.run_arc_challenge_eval(pbar)
-        if self.should_run(step, self.config.generate_every_x_steps, is_last_step):
+        if self.should_run(step, self.config.generation.generate_every_x_steps, is_last_step):
             self.run_generation(pbar)
 
     def start_training_loop(self):
@@ -1021,7 +1045,7 @@ class Trainer:
         current_step = self.trainer_state.current_step
         max_steps = self.trainer_state.max_steps
 
-        tqdm_label = f'Training ({self.config.training_stage.value})'
+        tqdm_label = f'Training ({self.config.training.stage.value})'
         abort_signal = torch.tensor([0], device=device)
 
         with self.torch_profiler_context as torch_profiler_ctx:

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -49,10 +49,7 @@ from config import (
     TrainingPrecision
 )
 from tokenizer import init_tokenizer
-from model import (
-    ModelConfig, 
-    Transformer
-)
+from model import (Transformer)
 from dataloaders import init_data_loaders
 from checkpoints import (
     save_checkpoint,
@@ -117,16 +114,16 @@ class Trainer:
         config = self.config
 
         # device type
-        if self.config.device_type != DeviceType.CUDA:
+        if self.config.runtime.device_type != DeviceType.CUDA:
             raise ValueError('Only cuda is supported at the moment.')
 
         # model config
-        if config.dim % config.n_heads != 0:
-            raise ValueError(f'"dim" ({config.dim}) must be divisible by "n_heads" ({config.n_heads})')
-        if config.n_kv_heads > config.n_heads:
-            raise ValueError(f'"n_kv_heads" ({config.n_kv_heads}) must be less or equal to "n_heads" ({config.n_heads})')
-        if config.n_heads % config.n_kv_heads != 0:
-            raise ValueError(f'"n_heads" ({config.n_heads}) must be divisible by n_kv_heads" ({config.n_kv_heads})')
+        if config.model.dim % config.model.n_heads != 0:
+            raise ValueError(f'"dim" ({config.model.dim}) must be divisible by "n_heads" ({config.model.n_heads})')
+        if config.model.n_kv_heads > config.model.n_heads:
+            raise ValueError(f'"n_kv_heads" ({config.model.n_kv_heads}) must be less or equal to "n_heads" ({config.model.n_heads})')
+        if config.model.n_heads % config.model.n_kv_heads != 0:
+            raise ValueError(f'"n_heads" ({config.model.n_heads}) must be divisible by n_kv_heads" ({config.model.n_kv_heads})')
 
     def setup(self):
         self.setup_global_torch_optimizations()
@@ -190,20 +187,23 @@ class Trainer:
         self.task_assets = self.task.build_assets(tokenizer=self.tokenizer, model=self.model)
 
     def build_distributed_context(self):
-        ddp, ddp_rank, ddp_local_rank, ddp_world_size, is_master_process, device = init_multi_gpu(self.config.seed, self.config.device_type.value)
+        ddp, ddp_rank, ddp_local_rank, ddp_world_size, is_master_process, device = init_multi_gpu(
+            self.config.training.seed,
+            self.config.runtime.device_type.value
+        )
         self.distributed_ctx = DistributedContext(
             ddp=ddp,
             ddp_rank=ddp_rank,
             ddp_local_rank=ddp_local_rank,
             ddp_world_size=ddp_world_size,
-            use_fsdp=self.config.use_fsdp,
+            use_fsdp=self.config.runtime.use_fsdp,
             is_master_process=is_master_process
         )
         return device
 
     def build_device_context(self, device):
         self.device_ctx = DeviceContext(
-            device_type=self.config.device_type.value,
+            device_type=self.config.runtime.device_type.value,
             device=device
         )
 
@@ -211,7 +211,7 @@ class Trainer:
         logger.set_master(self.distributed_ctx.is_master_process)
 
     def build_precision_context(self):
-        if self.config.training_precision == TrainingPrecision.BF16:
+        if self.config.runtime.training_precision == TrainingPrecision.BF16:
             self.precision_ctx = PrecisionContext(
                 use_autocast=True,
                 scaler=None,
@@ -220,7 +220,7 @@ class Trainer:
                 fsdp_mp=MixedPrecisionPolicy(
                     param_dtype=torch.bfloat16,
                     reduce_dtype=torch.float32
-                ) if self.config.use_fsdp else None
+                ) if self.config.runtime.use_fsdp else None
             )
         elif self.config.training_precision == TrainingPrecision.FP16:
             self.precision_ctx = PrecisionContext(
@@ -248,14 +248,14 @@ class Trainer:
         #### BATCH SIZE CHECKS
         # NOTE: total_batch_size is the total batch size in tokens. The model max_batch_size is the number of sequences per device during forward pass (micro batches).
         # The total batch size must be a multiple of (max_batch_size * max_seq_len * ddp_world_size). This is needed for the gradient accumulation steps to be calculated correctly.
-        if self.config.total_batch_size % (self.config.max_batch_size * self.config.max_seq_len * ddp_world_size) != 0:
+        if self.config.training.total_batch_size % (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size) != 0:
             raise ValueError('total_batch_size must be divisible by (max_batch_size * max_seq_len * ddp_world_size)')
 
         # Gradient accumulation steps
-        grad_accum_steps = self.config.total_batch_size // (self.config.max_batch_size * self.config.max_seq_len * ddp_world_size)
+        grad_accum_steps = self.config.training.total_batch_size // (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size)
 
         # Final check to validate previous calculations.
-        if self.config.total_batch_size != (self.config.max_batch_size * self.config.max_seq_len * ddp_world_size * grad_accum_steps):
+        if self.config.training.total_batch_size != (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size * grad_accum_steps):
             raise ValueError('total batch size MUST EQUAL (max_batch_size * max_seq_len * ddp_world_size * grad_accum_steps)')
 
         return grad_accum_steps
@@ -269,88 +269,87 @@ class Trainer:
         )
 
     def load_test_generation_prompts(self):
-        if self.config.generate_every_x_steps <= 0:
+        if self.config.generation.generate_every_x_steps <= 0:
             return
-        test_prompts_data=json.loads(Path(self.config.test_prompts_path).read_text())
-        stage = self.config.training_stage.value
+        test_prompts_data=json.loads(Path(self.config.paths.test_prompts_path).read_text())
+        stage = self.config.training.stage.value
         if stage not in test_prompts_data:
             raise ValueError(f'Missing test prompts for training stage: {stage}')
         self.test_generation_prompts = test_prompts_data[stage]
 
     def load_hellaswag_eval_data(self):
-        if self.config.hellaswag_every_x_steps <= 0 or self.config.training_stage != TrainingStage.PRETRAIN:
+        if self.config.evals.hellaswag.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
             return
         self.hellaswag_data = load_multiple_choice_eval_file(
-            filepath=f'{self.config.hellaswag_path}/hellaswag_val.jsonl',
+            filepath=f'{self.config.paths.evals.hellaswag_path}/hellaswag_val.jsonl',
             ddp=self.distributed_ctx.ddp,
             is_master_process=self.distributed_ctx.is_master_process,
-            size=self.config.hellaswag_number_of_examples
+            size=self.config.evals.hellaswag.number_of_examples
         )
 
     def load_winogrande_eval_data(self):
-        if self.config.winogrande_every_x_steps <= 0 or self.config.training_stage != TrainingStage.PRETRAIN:
+        if self.config.evals.winogrande.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
             return
         self.winogrande_data = load_multiple_choice_eval_file(
-            filepath=f'{self.config.winogrande_path}/winogrande_val.jsonl',
+            filepath=f'{self.config.paths.evals.winogrande_path}/winogrande_val.jsonl',
             ddp=self.distributed_ctx.ddp,
             is_master_process=self.distributed_ctx.is_master_process,
-            size=self.config.winogrande_number_of_examples
+            size=self.config.evals.winogrande.number_of_examples
         )
 
     def load_arc_challenge_eval_data(self):
-        if self.config.arc_challenge_every_x_steps <= 0 or self.config.training_stage != TrainingStage.PRETRAIN:
+        if self.config.evals.arc_challenge.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAIN:
             return
         self.arc_challenge_data = load_multiple_choice_eval_file(
-            filepath=f'{self.config.arc_challenge_path}/arc_challenge_val.jsonl',
+            filepath=f'{self.config.paths.evals.arc_challenge_path}/arc_challenge_val.jsonl',
             ddp=self.distributed_ctx.ddp,
             is_master_process=self.distributed_ctx.is_master_process,
-            size=self.config.arc_challenge_number_of_examples
+            size=self.config.evals.arc_challenge.number_of_examples
         )
     
     def build_tokenizer(self):
-        self.tokenizer = init_tokenizer(self.config.tokenizer_checkpoint_path, self.config.huggingface_tokenizer)
+        self.tokenizer = init_tokenizer(
+            self.config.tokenizer.checkpoint_path,
+            self.config.tokenizer.huggingface_tokenizer
+        )
 
     def build_model(self):
-        config = self.config
-        tokenizer = self.tokenizer
-        self.model_config = ModelConfig(
-            dim=config.dim,
-            n_layers=config.n_layers,
-            n_heads=config.n_heads,
-            n_kv_heads=config.n_kv_heads,
-            multiple_of=config.multiple_of,
-            ffn_dim_multiplier=config.ffn_dim_multiplier,
-            norm_eps=config.norm_eps,
-            rope_theta=config.rope_theta,
-            max_batch_size=config.max_batch_size,
-            max_seq_len=config.max_seq_len,
-            # tokenizer aux config
-            tokenizer=tokenizer,
-            vocab_size=tokenizer.vocab_size,
-            pad_token_id=tokenizer.pad_id,
-            stop_tokens=tokenizer.stop_tokens,
-            ignore_index=config.ignore_index,
-            # moe
-            is_moe=config.is_moe,
-            moe_num_experts=config.moe_num_experts,
-            moe_expert_dim=config.moe_expert_dim,
-            moe_top_k=config.moe_top_k,
-            moe_load_balancing_coef=config.moe_load_balancing_coef,
-            moe_z_loss_coef=config.moe_z_loss_coef,
-            moe_compute_stats=config.moe_compute_stats
+        self.model = Transformer(
+            self.config.model,
+            self.tokenizer,
+            self.config.tokenizer.ignore_index
         )
-        self.model = Transformer(self.model_config)
+
+    def is_pretraining(self):
+        return self.config.training.stage == TrainingStage.PRETRAIN
+
+    def is_instruct(self):
+        return self.config.training.stage == TrainingStage.INSTRUCT
+
+    def is_dpo(self):
+        return self.config.training.stage == TrainingStage.DPO
+
+    def get_dataloader_root_path(self):
+        dataloaders_paths = self.config.paths.dataloaders
+        if self.is_pretraining():
+            return dataloaders_paths.pretrain_root_path
+        elif is_instruct():
+            return dataloaders_paths.instruct_root_path
+        elif is_dpo():
+            return dataloaders_paths.dpo
+        else:
+            raise ValueError('No valid dataloader root path')
 
     def build_data_loaders(self):
         self.train_loader, self.val_loader = init_data_loaders(
-            batch_size=self.config.max_batch_size,
-            sequence_length=self.config.max_seq_len,
+            batch_size=self.config.model.max_batch_size,
+            sequence_length=self.config.model.max_seq_len,
             is_master_process=self.distributed_ctx.is_master_process,
             process_rank=self.distributed_ctx.ddp_rank,
             num_processes=self.distributed_ctx.ddp_world_size,
-            data_root=self.config.dataloader_root_path,
+            data_root=self.get_dataloader_root_path(),
             pad_id=self.tokenizer.pad_id,
-            training_stage=self.config.training_stage.value
+            training_stage=self.config.training.stage.value
         )
 
     def resolve_checkpoint_request(self):

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -268,8 +268,6 @@ class Trainer:
         )
 
     def load_test_generation_prompts(self):
-        if self.config.generation.generate_every_x_steps <= 0:
-            return
         test_prompts_data=json.loads(Path(self.config.paths.test_prompts_path).read_text())
         stage = self.config.training.stage.value
         if stage not in test_prompts_data:
@@ -277,7 +275,7 @@ class Trainer:
         self.test_generation_prompts = test_prompts_data[stage]
 
     def load_hellaswag_eval_data(self):
-        if self.config.evals.hellaswag.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
+        if self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.hellaswag_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.hellaswag_path}/hellaswag_val.jsonl',
@@ -287,7 +285,7 @@ class Trainer:
         )
 
     def load_winogrande_eval_data(self):
-        if self.config.evals.winogrande.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
+        if self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.winogrande_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.winogrande_path}/winogrande_val.jsonl',
@@ -297,7 +295,7 @@ class Trainer:
         )
 
     def load_arc_challenge_eval_data(self):
-        if self.config.evals.arc_challenge.every_x_steps <= 0 or self.config.training.stage != TrainingStage.PRETRAINING:
+        if self.config.training.stage != TrainingStage.PRETRAINING:
             return
         self.arc_challenge_data = load_multiple_choice_eval_file(
             filepath=f'{self.config.paths.evals.arc_challenge_path}/arc_challenge_val.jsonl',
@@ -369,13 +367,13 @@ class Trainer:
         path = None
         name = None
         if args.pretraining_checkpoint:
-            path = self.config.pretraining_load_checkpoints_path
+            path = self.config.paths.checkpoints.pretraining_load_path
             name = args.pretraining_checkpoint
         elif args.instruct_checkpoint:
-            path = self.config.instruct_load_checkpoints_path
+            path = self.config.paths.checkpoints.instruct_load_path
             name = args.instruct_checkpoint
         elif args.dpo_checkpoint:
-            path = self.config.dpo_load_checkpoints_path
+            path = self.config.paths.checkpoints.dpo_load_path
             name = args.dpo_checkpoint
         return (path, name)
 
@@ -390,7 +388,7 @@ class Trainer:
         )
 
         training_stage_changed = (
-            checkpoint_data.metadata.get('training_stage', None) != self.config.training_stage.value
+            checkpoint_data.metadata.get('training_stage', None) != self.config.training.stage.value
         )
         if training_stage_changed:
             logger.warn('Training stage has changed')
@@ -405,7 +403,7 @@ class Trainer:
             logger.warn('DDP world size has changed')
 
         lora_mode_changed = (
-            self.config.lora_enabled and
+            self.config.lora.enabled and
             checkpoint_data is not None and
             not checkpoint_data.is_lora_checkpoint
         )
@@ -447,7 +445,7 @@ class Trainer:
 
     def apply_lora_for_checkpoint(self):
         if self.checkpoint_data.is_lora_checkpoint:
-            if not self.config.lora_enabled:
+            if not self.config.lora.enabled:
                 raise ValueError('"lora_enabled" must be set to True when loading checkpoint that includes LoRA')
             self.apply_lora_modification()
 
@@ -624,16 +622,29 @@ class Trainer:
             logger.info(log, pbar=pbar)
         self.wandb.log(wanb_log)
 
-    def should_run(self, step, every, last_step, run_last_step=True, force_first_step=False):
-        if every == -1:
-            return run_last_step and last_step
+    def should_run(
+        self,
+        *,
+        run_config
+    ):
+        ''' Relies in the config properties: every_x_steps, run_on_first_step, run_on_last_step
+        '''
+        step = self.trainer_state.current_step
+        is_first_step = (step == 0)
+        is_last_step = self.trainer_state.is_last_step
+
+        every = run_config.every_x_steps
+        run_on_first_step = run_config.run_on_first_step
+        run_on_last_step = run_config.run_on_last_step
+
+        if (
+            (is_first_step and run_on_first_step) or
+            (is_last_step and run_on_last_step)
+        ):
+            return True
         if every <= 0:
             return False
-        return (
-            (step > 0 and step % every == 0) or
-            (run_last_step and last_step) or
-            (force_first_step and every != -1 and step == 0)
-        )
+        return step > 0 and step % every == 0
 
     def clip_grad_norm(self, model, max_norm):
         norm = clip_grad_norm_(model.parameters(), max_norm)
@@ -884,12 +895,6 @@ class Trainer:
         ):
             return
 
-        if math.isinf(self.trainer_state.best_val_loss):
-            # Do not save until we have at least one validation result.
-            msg = logger.warning_wrapper('skipping checkpointing as validation step was not performed yet.')
-            logger.info(f'{self.trainer_state.current_step:4d} | {msg}', pbar=pbar)
-            return
-
         logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
         save_checkpoint(
             self.get_save_checkpoints_path(),
@@ -1020,21 +1025,18 @@ class Trainer:
         logger.info('-----------------------------------------------', pbar=pbar)
 
     def process_step(self, pbar):
-        step = self.trainer_state.current_step
-        is_last_step = self.trainer_state.is_last_step
-
         self.run_train(pbar)
-        if self.should_run(step, self.config.validation.validate_every_x_steps, is_last_step, force_first_step=True):
+        if self.should_run(run_config=self.config.validation):
             self.run_validation(pbar)
-        if self.should_run(step, self.config.checkpointing.save_every_x_steps, is_last_step):
+        if self.should_run(run_config=self.config.checkpointing):
             self.run_save_checkpoint(pbar)
-        if self.should_run(step, self.config.evals.hellaswag.every_x_steps, is_last_step):
+        if self.should_run(run_config=self.config.evals.hellaswag):
             self.run_hellaswag_eval(pbar)
-        if self.should_run(step, self.config.evals.winogrande.every_x_steps, is_last_step):
+        if self.should_run(run_config=self.config.evals.winogrande):
             self.run_winogrande_eval(pbar)
-        if self.should_run(step, self.config.evals.arc_challenge.every_x_steps, is_last_step):
+        if self.should_run(run_config=self.config.evals.arc_challenge):
             self.run_arc_challenge_eval(pbar)
-        if self.should_run(step, self.config.generation.generate_every_x_steps, is_last_step):
+        if self.should_run(run_config=self.config.generation):
             self.run_generation(pbar)
 
     def start_training_loop(self):

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -330,13 +330,13 @@ class Trainer:
         return self.config.training.stage == TrainingStage.DPO
 
     def get_dataloader_root_path(self):
-        dataloaders_paths = self.config.paths.dataloaders
+        datasets_paths = self.config.paths.datasets
         if self.is_pretraining():
-            return dataloaders_paths.pretraining_root_path
+            return datasets_paths.pretraining_path
         elif self.is_instruct():
-            return dataloaders_paths.instruct_root_path
+            return datasets_paths.instruct_path
         elif self.is_dpo():
-            return dataloaders_paths.dpo_root_path
+            return datasets_paths.dpo_path
         else:
             raise ValueError('No valid dataloader root path')
 

--- a/generate.py
+++ b/generate.py
@@ -2,6 +2,7 @@ import torch
 
 from collections import defaultdict
 from kv_cache import KVCache
+from config import TokenizerConfig
 
 
 def sample_top_p(probs, p):
@@ -89,8 +90,25 @@ def build_tokens(tokens, prompt_tokens, stop_tokens, max_gen_len):
     return out_tokens
 
 @torch.no_grad()
-def generate(model, prompt_tokens, max_gen_len, temperature, top_p, repetition_penalty, no_repeat_ngram_size, device, use_kv_cache=False):
+def generate(
+    *,
+    prompt_tokens,
+    model,
+    tokenizer,
+    max_gen_len,
+    temperature,
+    top_p,
+    repetition_penalty,
+    no_repeat_ngram_size,
+    device,
+    dtype,
+    use_kv_cache=False
+):
     batch_size = len(prompt_tokens)
+
+    vocab_size = tokenizer.vocab_size
+    pad_token_id = tokenizer.pad_id
+    stop_tokens = tokenizer.stop_tokens
 
     # Finding the boundaries / limits.
     min_prompt_len = min(len(t) for t in prompt_tokens)
@@ -101,16 +119,15 @@ def generate(model, prompt_tokens, max_gen_len, temperature, top_p, repetition_p
     total_len = min(model.config.max_seq_len, max_gen_len + max_prompt_len)
 
     # Here we assume we receive a batch of multiple tokenized sequences.
-    pad_id = model.config.pad_token_id
-    tokens = torch.full((batch_size, total_len), pad_id, dtype=torch.long, device=device)
+    tokens = torch.full((batch_size, total_len), pad_token_id, dtype=torch.long, device=device)
 
     for batch, tokens_list in enumerate(prompt_tokens):
         tokens[batch, : len(tokens_list)] = torch.tensor(tokens_list, dtype=torch.long, device=device)
 
     # Define stop conditions, input mask and the stop tokens (extracted from the tokenizer)
     eos_reached = torch.tensor([False] * batch_size, device=device)
-    input_text_mask = tokens != pad_id
-    stop_tokens = torch.tensor(list(model.config.stop_tokens), device=device)
+    input_text_mask = tokens != pad_token_id
+    stop_tokens = torch.tensor(list(stop_tokens), device=device)
 
     current_position = min_prompt_len
 
@@ -124,10 +141,10 @@ def generate(model, prompt_tokens, max_gen_len, temperature, top_p, repetition_p
             n_kv_heads=model.config.n_kv_heads or model.config.n_heads,
             head_dim=model.config.dim // model.config.n_heads,
             device=device,
-            dtype=model.tok_embeddings.weight.dtype
+            dtype=dtype
         )
 
-    out = model.forward(tokens[:, :current_position], start_position=0, kv_cache=kv_cache)
+    out = model(tokens[:, :current_position], start_position=0, kv_cache=kv_cache)
 
     while current_position < total_len:
         logits = out['logits'][:, -1]
@@ -163,17 +180,18 @@ def generate(model, prompt_tokens, max_gen_len, temperature, top_p, repetition_p
         current_position += 1
 
         start_position = current_position - 1 if use_kv_cache else 0
-        out = model.forward(tokens[:, start_position : current_position], start_position=start_position, kv_cache=kv_cache)
+        out = model(tokens[:, start_position : current_position], start_position=start_position, kv_cache=kv_cache)
 
     # For all the sequences, we extract all tokens up to a stop_token if it exists.
-    out_tokens = build_tokens(tokens, prompt_tokens, model.config.stop_tokens, max_gen_len)
+    out_tokens = build_tokens(tokens, prompt_tokens, stop_tokens, max_gen_len)
 
     return out_tokens
 
 def generate_and_decode(
-        model,
-        texts,
         *,
+        texts,
+        model,
+        tokenizer,
         max_gen_len=256,
         temperature=0.6,
         top_p=0.9,
@@ -181,14 +199,16 @@ def generate_and_decode(
         no_repeat_ngram_size=1,
         full_seq=False,
         device='cpu',
+        dtype=torch.float32,
         is_instruct=False,
         skip_encoding=False,
         use_kv_cache=False
     ):
+        vocab_size = tokenizer.vocab_size
+        pad_token_id = tokenizer.pad_id
+
         if not isinstance(texts, list):
             texts = [texts]
-
-        tokenizer = model.config.tokenizer
 
         if not skip_encoding:
             if is_instruct:
@@ -199,19 +219,21 @@ def generate_and_decode(
             prompt_tokens = texts
         
         generation_tokens = generate(
-            model=model,
             prompt_tokens=prompt_tokens,
+            model=model,
+            tokenizer=tokenizer,
             max_gen_len=max_gen_len,
             temperature=temperature,
             top_p=top_p,
             repetition_penalty=repetition_penalty,
             no_repeat_ngram_size=no_repeat_ngram_size,
             device=device,
+            dtype=dtype,
             use_kv_cache=use_kv_cache
         )
 
         def validate_token(tokens):
-            return [token if token < model.config.vocab_size else model.config.pad_token_id for token in tokens]
+            return [token if token < vocab_size else pad_token_id for token in tokens]
 
         results = [tokenizer.decode(validate_token(t)) for t in generation_tokens]
 

--- a/generate.py
+++ b/generate.py
@@ -101,7 +101,7 @@ def generate(
     repetition_penalty,
     no_repeat_ngram_size,
     device,
-    dtype,
+    dtype=torch.float32,
     use_kv_cache=False
 ):
     batch_size = len(prompt_tokens)

--- a/model.py
+++ b/model.py
@@ -297,11 +297,11 @@ class TransformerBlock(nn.Module):
                 hidden_dim=4 * config.dim,
                 multiple_of=config.multiple_of,
                 ffn_dim_multiplier=config.ffn_dim_multiplier,
-                num_experts=config.moe_num_experts,
-                expert_dim=config.moe_expert_dim,
-                top_k=config.moe_top_k,
-                load_balancing_coef=config.moe_load_balancing_coef,
-                z_loss_coef=config.moe_z_loss_coef
+                num_experts=config.moe.num_experts,
+                expert_dim=config.moe.expert_dim,
+                top_k=config.moe.top_k,
+                load_balancing_coef=config.moe.load_balancing_coef,
+                z_loss_coef=config.moe.z_loss_coef
             )
         else:
             self.feed_forward = FeedForward(
@@ -325,14 +325,19 @@ class TransformerBlock(nn.Module):
         return output, aux
 
 class Transformer(nn.Module):
-    def __init__(self, config: ModelConfig, tokenizer, ignore_index):
+    def __init__(
+        self,
+        *,
+        config: ModelConfig,
+        pad_token_id,
+        vocab_size,
+        ignore_index
+    ):
         super(Transformer, self).__init__()
 
         self.config = config
-        self.tokenizer = tokenizer
-        self.vocab_size = tokenizer.vocab_size
-        self.pad_token_id = tokenizer.pad_id
-        self.stop_tokens = tokenizer.stop_tokens
+        self.pad_token_id = pad_token_id
+        self.vocab_size = vocab_size
         self.ignore_index = ignore_index
 
         self.n_layers = config.n_layers
@@ -379,21 +384,21 @@ class Transformer(nn.Module):
                 m.compute_stats = enabled
 
     def enable_moe_stats(self):
-        if self.config.is_moe and self.config.moe_compute_stats:
+        if self.config.moe.enabled and self.config.moe.compute_stats:
             self.set_moe_stats(True)
 
     def disable_moe_stats(self):
-        if self.config.is_moe and self.config.moe_compute_stats:
+        if self.config.moe.enabled and self.config.moe.compute_stats:
             self.set_moe_stats(False)
 
     def reset_moe_stats(self):
-        if self.config.is_moe and self.config.moe_compute_stats:
+        if self.config.moe.enabled and self.config.moe.compute_stats:
             for m in self.modules():
                 if isinstance(m, MoEFeedForward):
                     m.reset_stats()
 
     def get_moe_stats(self):
-        if not self.config.is_moe or (not self.config.moe_compute_stats):
+        if not self.config.moe.enabled or (not self.config.moe.compute_stats):
             return []
         stats = []
         for layer_id, block in enumerate(self.layers):

--- a/model.py
+++ b/model.py
@@ -1,63 +1,10 @@
 import torch
 import torch.nn.functional as F
-import json
 
 from torch import nn
-from dataclasses import dataclass
 from kv_cache import KVCache
+from config import ModelConfig
 
-
-@dataclass
-class ModelConfig:
-    dim: int
-    n_layers: int
-    n_heads: int
-    n_kv_heads: int
-    multiple_of: int
-    ffn_dim_multiplier: float
-    norm_eps: float
-    rope_theta: float
-    max_batch_size: int
-    max_seq_len: int
-    tokenizer: object = None
-    vocab_size: int = None
-    pad_token_id: int = None
-    stop_tokens: object = None
-    ignore_index: int = None
-    is_moe: bool = False
-    moe_num_experts: int = None
-    moe_expert_dim: int = None
-    moe_top_k: int = None
-    moe_load_balancing_coef: float = None
-    moe_z_loss_coef: float = None
-    moe_compute_stats: bool = False
-
-    def to_dict(self):
-        return {
-            'dim': self.dim,
-            'n_layers': self.n_layers,
-            'n_heads': self.n_heads,
-            'n_kv_heads': self.n_kv_heads,
-            'vocab_size': self.vocab_size,
-            'multiple_of': self.multiple_of,
-            'ffn_dim_multiplier': self.ffn_dim_multiplier,
-            'norm_eps': self.norm_eps,
-            'rope_theta': self.rope_theta,
-            'max_batch_size': self.max_batch_size,
-            'max_seq_len': self.max_seq_len,
-            'pad_token_id': self.pad_token_id,
-            'stop_tokens': list(self.stop_tokens),
-            'is_moe': self.is_moe,
-            'moe_num_experts': self.moe_num_experts,
-            'moe_expert_dim': self.moe_expert_dim,
-            'moe_top_k': self.moe_top_k,
-            'moe_load_balancing_coef': self.moe_load_balancing_coef,
-            'moe_z_loss_coef': self.moe_z_loss_coef,
-            'moe_compute_stats': self.moe_compute_stats
-        }
-
-    def __repr__(self):
-        return json.dumps(self.to_dict(), indent=4)
 
 def precompute_rope_freqs(head_dim, sequence_length, theta=10000.0, device='cpu', dtype=torch.float32):
     ''' Computes the frequencies that will be used for rope (rotary positional ebedding). Without complex numbers.
@@ -342,9 +289,9 @@ class TransformerBlock(nn.Module):
         self.n_heads = config.n_heads
         self.dim = config.dim
         self.attention = Attention(config)
-        self.is_moe = config.is_moe
+        self.is_moe = config.moe.enabled
 
-        if config.is_moe:
+        if self.is_moe:
             self.feed_forward = MoEFeedForward(
                 dim=config.dim,
                 hidden_dim=4 * config.dim,
@@ -378,18 +325,22 @@ class TransformerBlock(nn.Module):
         return output, aux
 
 class Transformer(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: ModelConfig, tokenizer, ignore_index):
         super(Transformer, self).__init__()
 
         self.config = config
+        self.tokenizer = tokenizer
+        self.vocab_size = tokenizer.vocab_size
+        self.pad_token_id = tokenizer.pad_id
+        self.stop_tokens = tokenizer.stop_tokens
+        self.ignore_index = ignore_index
 
-        self.vocab_size = config.vocab_size
         self.n_layers = config.n_layers
 
         self.tok_embeddings = nn.Embedding(
-            config.vocab_size,
+            self.vocab_size,
             config.dim,
-            padding_idx=config.pad_token_id
+            padding_idx=self.pad_token_id
         )
 
         self.layers = nn.ModuleList()
@@ -397,9 +348,7 @@ class Transformer(nn.Module):
             self.layers.append(TransformerBlock(layer_id, config))
 
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
-        self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
-
-        self.ignore_index = config.ignore_index
+        self.output = nn.Linear(config.dim, self.vocab_size, bias=False)
 
         rope_freqs = precompute_rope_freqs(
             config.dim // config.n_heads,

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,7 +4,7 @@ from tasks.dpo import DPOTask
 from config import TrainingStage
 
 def get_task(training_stage):
-    if training_stage == TrainingStage.PRETRAIN:
+    if training_stage == TrainingStage.PRETRAINING:
         return PretrainingTask()
     elif training_stage == TrainingStage.INSTRUCT:
         return InstructTask()

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -24,11 +24,11 @@ class CausalTask(BaseTask):
 
     def build_assets(self, tokenizer, model):
         config = self.config
-        if not config.is_model_distillation:
+        if not config.distillation.enabled:
             return CausalTaskAssets()
         ddp_rank = self.ctx.distributed.ddp_rank
         logger.info(f'Loading teacher model on gpu: {ddp_rank}...', True)
-        teacher_model = AutoModelForCausalLM.from_pretrained(config.teacher_model_checkpoint, token=config.hf_token)
+        teacher_model = AutoModelForCausalLM.from_pretrained(config.distillation.teacher_model_checkpoint, token=config.third_party.hf_token)
         if teacher_model.vocab_size != tokenizer.vocab_size:
             logger.warn(f'The sizes of the vocabularies for the teacher model and the tokenizer do not match: {teacher_model.vocab_size} != {tokenizer.vocab_size}\nResizing the vocab of the teacher model to match the tokenizer... NOTE: This can potentially cause issues.')
             teacher_model.resize_token_embeddings(tokenizer.vocab_size)
@@ -70,7 +70,7 @@ class CausalTask(BaseTask):
             'Train Loss': loss.detach()
         }
 
-        if self.config.is_model_distillation:
+        if self.config.distillation.enabled:
             tokens_processed += x.numel()
 
             with torch.no_grad():
@@ -79,7 +79,7 @@ class CausalTask(BaseTask):
             loss_distil = distillation_loss(
                 teacher_logits,
                 result['logits'],
-                temperature=self.config.distillation_temperature
+                temperature=self.config.distillation.temperature
             )
             loss_for_backward = loss_for_backward + loss_distil
 
@@ -88,7 +88,7 @@ class CausalTask(BaseTask):
 
         loss_for_backward = loss_for_backward / grad_accum_steps
 
-        n_valid = (y != self.config.ignore_index).sum()
+        n_valid = (y != self.config.tokenizer.ignore_index).sum()
 
         return TaskStepOutput(
             tokens_processed=tokens_processed,
@@ -112,7 +112,7 @@ class CausalTask(BaseTask):
         with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
             loss = model(x, labels=y)['loss']
         
-        n_valid = (y != self.config.ignore_index).sum().float()
+        n_valid = (y != self.config.tokenizer.ignore_index).sum().float()
 
         return TaskStepOutput(
             n_valid=n_valid,

--- a/tasks/dpo.py
+++ b/tasks/dpo.py
@@ -26,8 +26,6 @@ class DPOTask(BaseTask):
         return self
 
     def build_assets(self, tokenizer, model):
-        if not self.config.is_dpo_training:
-            return DPOTaskAssets()
         model_dtype = self.ctx.precision.model_dtype
         logger.info(f'Preparing DPO reference model...', True)
         dpo_ref_model = copy.deepcopy(model).eval()
@@ -50,7 +48,7 @@ class DPOTask(BaseTask):
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
         grad_accum_steps = self.ctx.grad_accum_steps
-        dpo_beta = self.config.dpo_beta
+        dpo_beta = self.config.dpo.beta
 
         # x, y, z = prompt, chosen, rejected
         x, y, z = batch
@@ -102,7 +100,7 @@ class DPOTask(BaseTask):
         device_type = self.ctx.device.device_type
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
-        dpo_beta = self.config.dpo_beta
+        dpo_beta = self.config.dpo.beta
 
         # x, y, z = prompt, chosen, rejected
         x, y, z = batch

--- a/test_prompts.json
+++ b/test_prompts.json
@@ -1,5 +1,5 @@
 {
-    "pretrain": [
+    "pretraining": [
         "Cats are curious animals that",
         "A computer is a machine that",
         "The capital of France is",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,8 @@ import pytest
 import torch
 
 from tokenizer import init_tokenizer
-from model import Transformer, ModelConfig
+from model import Transformer
+from config import ModelConfig
 
 
 @pytest.fixture(scope='session')
@@ -37,14 +38,15 @@ def model(device, tokenizer):
         norm_eps=1e-05,
         rope_theta=500000.0,
         max_batch_size=2,
-        max_seq_len=32,
-        tokenizer = tokenizer,
-        vocab_size = tokenizer.vocab_size,
-        pad_token_id = tokenizer.pad_id,
-        stop_tokens = tokenizer.stop_tokens
+        max_seq_len=32
     )
 
-    model = Transformer(model_config)
+    model = Transformer(
+        config=model_config,
+        pad_token_id=tokenizer.pad_id,
+        vocab_size=tokenizer.vocab_size,
+        ignore_index=-100
+    )
     model.to(device)
     model.eval()
     return model

--- a/tests/test_attention_masks.py
+++ b/tests/test_attention_masks.py
@@ -2,11 +2,11 @@ import torch
 
 
 @torch.no_grad()
-def test_padded_batch_matches_individual(model, device):
+def test_padded_batch_matches_individual(model, tokenizer, device):
     model.eval()
     torch.manual_seed(0)
 
-    pad_id = model.config.pad_token_id
+    pad_id = tokenizer.pad_id
 
     # Two sequences with different lengths
     seq1 = [10, 20, 30, 40, 50]      # len 5

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,7 +3,7 @@ import torch
 from generate import generate
 
 
-def test_generate_kv_cache_matches_no_cache_greedy(model, device):
+def test_generate_kv_cache_matches_no_cache_greedy(model, tokenizer, device):
     model.eval()
     torch.manual_seed(0)
 
@@ -16,13 +16,14 @@ def test_generate_kv_cache_matches_no_cache_greedy(model, device):
 
     kwargs = dict(
         model=model,
+        tokenizer=tokenizer,
         prompt_tokens=prompts,
         max_gen_len=16,
         temperature=0.0,
         top_p=0.9, # ignored when temperature=0
         repetition_penalty=1.0,
         no_repeat_ngram_size=1,
-        device=device,
+        device=device
     )
 
     out_no_cache = generate(**kwargs, use_kv_cache=False)
@@ -30,7 +31,7 @@ def test_generate_kv_cache_matches_no_cache_greedy(model, device):
 
     assert out_no_cache == out_cache
 
-def test_generate_batched_variable_lengths_smoke(model, device):
+def test_generate_batched_variable_lengths_smoke(model, tokenizer, device):
     model.eval()
     torch.manual_seed(0)
 
@@ -44,6 +45,7 @@ def test_generate_batched_variable_lengths_smoke(model, device):
 
     out = generate(
         model=model,
+        tokenizer=tokenizer,
         prompt_tokens=prompts,
         max_gen_len=max_gen_len,
         temperature=0.0,
@@ -61,11 +63,12 @@ def test_generate_batched_variable_lengths_smoke(model, device):
         assert isinstance(gen_tokens, list)
         assert len(gen_tokens) <= max_gen_len
 
-def test_generate_empty_prompt_raises(model, device):
+def test_generate_empty_prompt_raises(model, tokenizer, device):
     with torch.no_grad():
         try:
             generate(
                 model=model,
+                tokenizer=tokenizer,
                 prompt_tokens=[[1, 2, 3], []], # one empty prompt
                 max_gen_len=8,
                 temperature=0.0,

--- a/tests/test_kv_cache.py
+++ b/tests/test_kv_cache.py
@@ -4,7 +4,7 @@ from kv_cache import KVCache
 
 
 @torch.no_grad()
-def test_kv_cache_matches_no_cache(model, device, dummy_prompt_tokens, steps=8):
+def test_kv_cache_matches_no_cache(model, tokenizer, device, dummy_prompt_tokens, steps=8):
     model.eval()
     torch.manual_seed(0)
 
@@ -14,7 +14,7 @@ def test_kv_cache_matches_no_cache(model, device, dummy_prompt_tokens, steps=8):
 
     batch_size = len(prompt_tokens)
 
-    pad_id = model.config.pad_token_id
+    pad_id = tokenizer.pad_id
     total_len = min(model.config.max_seq_len, max(len(t) for t in prompt_tokens) + steps)
 
     tokensA = torch.full((batch_size, total_len), pad_id, dtype=torch.long, device=device)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -114,7 +114,7 @@ class TikTokenizer(BaseTokenizer):
 class HFTokenizer(BaseTokenizer):
     def __init__(self, path):
         self.num_reserved_special_tokens = 256
-        self.model = AutoTokenizer.from_pretrained(path, token=config.hf_token)
+        self.model = AutoTokenizer.from_pretrained(path, token=config.third_party.hf_token)
         self.model.model_max_length = int(1e30)
 
         update_tokens = []

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -30,7 +30,7 @@ class BaseTokenizer(ABC):
         if system_msg:
             tokens.extend(self.encode('system'))
             tokens.extend([eh])
-            tokens.extend(self.encode('\n' + config.system_prompt))
+            tokens.extend(self.encode('\n' + config.prompts.system_prompt))
             tokens.extend([eot, sh])
         tokens.extend(self.encode('user'))
         tokens.extend([eh])

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ from engine import Trainer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Train Script Options')
-    parser.add_argument('--pretrain_checkpoint', type=str, default=None, help='Pretrain checkpoint to load.')
+    parser.add_argument('--pretraining_checkpoint', type=str, default=None, help='Pretraining checkpoint to load.')
     parser.add_argument('--instruct_checkpoint', type=str, default=None, help='Instruct checkpoint to load.')
     parser.add_argument('--dpo_checkpoint', type=str, default=None, help='DPO checkpoint to load.')
     parser.add_argument('--reset-optimizers', action='store_true', help='Reset the optimizers state when loading a checkpoint.')

--- a/train.py
+++ b/train.py
@@ -6,9 +6,9 @@ from engine import Trainer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Train Script Options')
-    parser.add_argument('--pretraining_checkpoint', type=str, default=None, help='Pretraining checkpoint to load.')
-    parser.add_argument('--instruct_checkpoint', type=str, default=None, help='Instruct checkpoint to load.')
-    parser.add_argument('--dpo_checkpoint', type=str, default=None, help='DPO checkpoint to load.')
+    parser.add_argument('--pretraining-checkpoint', type=str, default=None, help='Pretraining checkpoint to load.')
+    parser.add_argument('--instruct-checkpoint', type=str, default=None, help='Instruct checkpoint to load.')
+    parser.add_argument('--dpo-checkpoint', type=str, default=None, help='DPO checkpoint to load.')
     parser.add_argument('--reset-optimizers', action='store_true', help='Reset the optimizers state when loading a checkpoint.')
     parser.add_argument('--start-step', type=int, default=None, help='Starting step number for training.')
 

--- a/wandb_utils.py
+++ b/wandb_utils.py
@@ -10,7 +10,7 @@ class WandbWrapper():
         self.is_master_process = is_master_process
 
         if enabled and self.is_master_process:
-            WANDB_API_KEY = config.wandb_api_key
+            WANDB_API_KEY = config.third_party.wandb_api_key
             if WANDB_API_KEY is not None:
                 wandb.login(key=WANDB_API_KEY)
                 self.WANDB = True


### PR DESCRIPTION
Part of #10 

Moving the config to a more structured approach with nested components. Also removing derived properties and computing them in the trainer (cleaner). **NOTE** This will move the configuration from .env to "recipes" that will be introduced later. Config will only parse HF paths / tokens from the`.env` file.

Modifications:
- Refactor config into nested components;
- Derived properties computed in the trainer;
- Fixed a bug with FSDP2 when testing the prompts during training;
- Prepare config structure for future recipe loading(Will come in a future PR);