### PR TITLE
validate shard size in pretraining to prevent lock in DDP

### DIFF
--- a/dataloaders.py
+++ b/dataloaders.py
@@ -71,7 +71,6 @@ class PretrainingDataLoader:
         for shard_path in self.shards:
             shard = np.load(shard_path, mmap_mode='r', allow_pickle=False)
             shard_len = int(shard.shape[0])
-            del shard
 
             if shard_len < required_tokens:
                 raise ValueError(

--- a/dataloaders.py
+++ b/dataloaders.py
@@ -63,7 +63,22 @@ class PretrainingDataLoader:
         if is_master_process:
             logger.info(f'found {len(self.shards)} shards for split {split}')
 
+        self.validate_shards_size()
         self.reset()
+
+    def validate_shards_size(self):
+        required_tokens = self.B * self.S * self.ddp_world_size + 1
+        for shard_path in self.shards:
+            shard = np.load(shard_path, mmap_mode='r', allow_pickle=False)
+            shard_len = int(shard.shape[0])
+            del shard
+
+            if shard_len < required_tokens:
+                raise ValueError(
+                    f'Shard is too small for distributed training: {shard_path}. '
+                    f'Need a minimum of {required_tokens} tokens, got {shard_len}. '
+                    f'B={self.B}, S={self.S}, world_size={self.ddp_world_size}.'
+                )
 
     def calculate_max_tokens(self):
         if self.total_tokens:

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -105,7 +105,7 @@ data:
       sample-10BT:
         weight: 1.0
         transforms:
-          max_datapoints: 1000
+          max_datapoints: 10000
 
   evals:
     hellaswag:


### PR DESCRIPTION
Prevents a "lock/hang" that would happen if one of the ranks gets a shard that is too small for the configured batch size, sequence length and world size. Problem doesn't seem to be noticeable in 1GPU.

Modifications
- Increasing the number of datapoints to download in the pretraining debug recipe
- Added validation block in the dataloader to ensure the shards have a valid size 