### PR TITLE
Improving checkpointing (save dir path and load file path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ python train.py --recipe recipes/pretraining/debug.yaml
     torchrun \
       --standalone \
       --nproc_per_node <NUMBER_OF_GPUs> \
-      train.py --recipe recipes/pretraining/debug.yaml --checkpoint <CHECKPOINT_FILE_NAME>
+      train.py --recipe recipes/pretraining/debug.yaml --checkpoint <CHECKPOINT_FILE_PATH>
     ```
 
 - To train on multiple nodes with **1 or more GPUs per node**, configure each node as follows:

--- a/README.md
+++ b/README.md
@@ -174,9 +174,7 @@ HF_HOME='./cache'
   --pretraining                     # Automatically sets pretraining stage.
   --instruct                        # Automatically sets instruct stage.
   --dpo                             # Automatically sets DPO stage.
-  --pretraining-checkpoint <file>   # Resume pretraining run
-  --instruct-checkpoint <file>      # Resume SFT run
-  --dpo-checkpoint <file>           # Resume DPO run
+  --checkpoint <file>               # Resume training from a specific checkpoint
   --reset-optimizers                # Ignore stored optimizer(s) state
   --start-step <N>                  # Override internal step counter
 ```
@@ -213,7 +211,7 @@ python train.py --recipe recipes/pretraining/debug.yaml
     torchrun \
       --standalone \
       --nproc_per_node <NUMBER_OF_GPUs> \
-      train.py --recipe recipes/pretraining/debug.yaml --pretraining-checkpoint <CHECKPOINT_FILE_NAME>
+      train.py --recipe recipes/pretraining/debug.yaml --checkpoint <CHECKPOINT_FILE_NAME>
     ```
 
 - To train on multiple nodes with **1 or more GPUs per node**, configure each node as follows:

--- a/checkpoints.py
+++ b/checkpoints.py
@@ -113,8 +113,7 @@ def save_checkpoint(
 
 @dataclass
 class CheckpointData:
-    path: str | None = None
-    checkpoint_name: str | None = None
+    file_path: str | None = None
     model_state: dict[str, Any] | None = None
     optimizers_state: dict[str, Any] | None = None
     resume_step: int = 0
@@ -127,8 +126,7 @@ class CheckpointData:
 
     def to_dict(self):
         return {
-            'path': self.path,
-            'checkpoint_name': self.checkpoint_name,
+            'file_path': self.file_path,
             'resume_step': self.resume_step,
             'last_val_loss': self.last_val_loss if not math.isinf(self.last_val_loss) else None,
             'best_val_loss': self.best_val_loss if not math.isinf(self.best_val_loss) else None,
@@ -140,12 +138,10 @@ class CheckpointData:
         return json.dumps(self.to_dict(), indent=4)
 
 def load_checkpoint(
-    checkpoint_dir,
-    checkpoint,
+    file_path,
     is_master_process=True
 ):
-    checkpoint_path = os.path.join(checkpoint_dir, checkpoint)
-    state = torch.load(checkpoint_path, map_location='cpu', weights_only=True)
+    state = torch.load(file_path, map_location='cpu', weights_only=True)
 
     step = state['step'] + 1
     last_val_loss = state['last_val_loss'] if state['last_val_loss'] is not None else float('inf')
@@ -168,7 +164,7 @@ def load_checkpoint(
     if is_master_process:
         logger.info('\nModel checkpoint loading')
         logger.info('----------------------------------------')
-        logger.info(f'model state loaded from checkpoint: "{checkpoint}"')
+        logger.info(f'model state loaded from checkpoint file: "{file_path}"')
         if optimizers_state is not None:
             logger.info(f'optimizers state loaded from checkpoint')
             if optimizers_state['adamw']:
@@ -186,16 +182,14 @@ def load_checkpoint(
             logger.info('--Val Loader state:')
             logger.info({key: val_dl_state[key] for key in _valid_keys if key in val_dl_state})
 
-        try:
-            logger.info('\nLoaded config')
-            logger.info('----------------------------------------')
-            logger.info(state['config'], is_json=True)
+        logger.info('\nLoaded config')
+        logger.info('----------------------------------------')
+        logger.info(state['config'], is_json=True)
 
-            logger.info('\nLoaded model config')
-            logger.info('----------------------------------------')
-            logger.info(state['model_config'], is_json=True)
-        except:
-            logger.info('Error printing the config. Potential serialization problem. Should be resolved in the next save attempt.')
+        logger.info('\nLoaded model config')
+        logger.info('----------------------------------------')
+        logger.info(state['config'], is_json=True)
+
         if step > 0:
             logger.info(f'\nResuming from step: {step}')
         else:
@@ -214,8 +208,7 @@ def load_checkpoint(
         torch.cuda.empty_cache()
 
     return CheckpointData(
-        path=checkpoint_dir,
-        checkpoint_name=checkpoint,
+        file_path=file_path,
         model_state=model_state,
         optimizers_state=optimizers_state,
         resume_step=step,

--- a/config.py
+++ b/config.py
@@ -107,12 +107,8 @@ class EvalPathsConfig(BaseModel):
 
 class CheckpointPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    pretraining_save_path: str = './checkpoints/pretraining'
-    pretraining_load_path: str = './checkpoints/pretraining'
-    instruct_save_path: str = './checkpoints/instruct'
-    instruct_load_path: str = './checkpoints/instruct'
-    dpo_save_path: str = './checkpoints/dpo'
-    dpo_load_path: str = './checkpoints/dpo'
+    load_file_path: str | None = None
+    save_dir_path: str = './checkpoints'
 
 class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -373,39 +373,25 @@ class Trainer:
         )
 
     def resolve_checkpoint_request(self):
-        args = self.args
+        checkpoint_file_path = self.args.checkpoint or self.config.paths.checkpoints.load_file_path
 
-        selected = [
-            bool(args.pretraining_checkpoint),
-            bool(args.instruct_checkpoint),
-            bool(args.dpo_checkpoint),
-        ]
-        selected_sum = sum(selected)
-        if selected_sum == 0:
+        if checkpoint_file_path is None:
             return None
-        elif selected_sum > 1:
-            raise ValueError('Only one checkpoint argument can be provided.')
 
-        path = None
-        name = None
-        if args.pretraining_checkpoint:
-            path = self.config.paths.checkpoints.pretraining_load_path
-            name = args.pretraining_checkpoint
-        elif args.instruct_checkpoint:
-            path = self.config.paths.checkpoints.instruct_load_path
-            name = args.instruct_checkpoint
-        elif args.dpo_checkpoint:
-            path = self.config.paths.checkpoints.dpo_load_path
-            name = args.dpo_checkpoint
-        return (path, name)
+        checkpoint_file_path = Path(checkpoint_file_path)
 
-    def load_checkpoint_data(self, checkpoint_request):
+        if not checkpoint_file_path.exists():
+            raise FileNotFoundError(f'Checkpoint file does not exist: {checkpoint_file_path}')
+        if not checkpoint_file_path.is_file():
+            raise FileNotFoundError(f'Checkpoint path is not a file: {checkpoint_file_path}')
+
+        return str(checkpoint_file_path)
+
+    def load_checkpoint_data(self, checkpoint_file_path):
         args = self.args
-        path, name = checkpoint_request
 
         checkpoint_data = load_checkpoint(
-            path,
-            name,
+            file_path=checkpoint_file_path,
             is_master_process=self.distributed_ctx.is_master_process
         )
 
@@ -901,15 +887,12 @@ class Trainer:
         )
 
     def get_save_checkpoints_path(self):
-        checkpoints_paths = self.config.paths.checkpoints
-        if self.is_pretraining():
-            return checkpoints_paths.pretraining_save_path
-        elif self.is_instruct():
-            return checkpoints_paths.instruct_save_path
-        elif self.is_dpo():
-            return checkpoints_paths.dpo_save_path
-        else:
-            raise ValueError('No valid checkpointing path')
+        checkpoint_save_path = self.config.paths.checkpoints.save_dir_path
+
+        if checkpoint_save_path is None:
+            raise ValueError('Checkpoint save dir path must be set in the configuration: "config.paths.checkpoints.save_dir_path"')
+
+        return checkpoint_save_path
 
     def run_save_checkpoint(self, pbar=None):
         if (

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -43,8 +43,7 @@ config:
     datasets:
       dpo_path: ./datasets/debug/dpo
     checkpoints:
-      dpo_save_path: ./checkpoints/debug/dpo
-      dpo_load_path: ./checkpoints/debug/dpo
+      save_dir_path: ./checkpoints/debug/dpo
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -43,8 +43,7 @@ config:
     datasets:
       instruct_path: ./datasets/debug/instruct
     checkpoints:
-      instruct_save_path: ./checkpoints/debug/instruct
-      instruct_load_path: ./checkpoints/debug/instruct
+      save_dir_path: ./checkpoints/debug/instruct
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -44,8 +44,7 @@ config:
       winogrande_path: ./datasets/debug/winogrande
       arc_challenge_path: ./datasets/debug/arc_challenge
     checkpoints:
-      pretraining_save_path: ./checkpoints/debug/pretraining
-      pretraining_load_path: ./checkpoints/debug/pretraining
+      save_dir_path: ./checkpoints/debug/pretraining
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/train.py
+++ b/train.py
@@ -18,9 +18,7 @@ if __name__ == '__main__':
     stage_group.add_argument('--dpo', action='store_true', help='Forces DPO stage.')
 
     checkpoint_group = parser.add_mutually_exclusive_group()
-    checkpoint_group.add_argument('--pretraining-checkpoint', type=str, default=None, help='Pretraining checkpoint to load.')
-    checkpoint_group.add_argument('--instruct-checkpoint', type=str, default=None, help='Instruct checkpoint to load.')
-    checkpoint_group.add_argument('--dpo-checkpoint', type=str, default=None, help='DPO checkpoint to load.')
+    checkpoint_group.add_argument('--checkpoint', type=str, default=None, help='Checkpoint file path to load.')
 
     parser.add_argument('--reset-optimizers', action='store_true', help='Reset the optimizers state when loading a checkpoint.')
     parser.add_argument('--start-step', type=int, default=None, help='Starting step number for training.')


### PR DESCRIPTION
Closes #14 

Simplified how to configure checkpoint save dir and checkpoint load file.

Modifications:
- properties under config.paths.checkpoints are now `save_dir_path` and `load_file_path`:
  - `save_dir_path`: points to the directory where checkpoints are created.
  - `load_file_path`: points to the specific file we want to load.
- Loading using a flag is now done via  `--checkpoing <file_path>` flag.