### PR TITLE
Moving model specific config validation to model implemented method

### DIFF
--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -236,7 +236,7 @@ class Trainer:
             raise ValueError('Invalid training precision')
 
     def compute_grad_accum_steps(self, ddp_world_size):
-        #### BATCH SIZE CHECKS
+        #### BATCH SIZE CHECKS (For now assumes token based autoregressive training...)
         # NOTE: total_batch_size is the total batch size in tokens. The model max_batch_size is the number of sequences per device during forward pass (micro batches).
         # The total batch size must be a multiple of (max_batch_size * max_seq_len * ddp_world_size). This is needed for the gradient accumulation steps to be calculated correctly.
         if self.config.training.total_batch_size % (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size) != 0:

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -107,22 +107,14 @@ class Trainer:
         self.wandb = None
         self.torch_profiler_context = None
 
-        self.validate_config()
+        self.validate_common_config()
 
-    def validate_config(self):
+    def validate_common_config(self):
         config = self.config
 
         # device type
         if self.config.runtime.device_type != DeviceType.CUDA:
             raise ValueError('Only cuda is supported at the moment.')
-
-        # model config
-        if config.model.dim % config.model.n_heads != 0:
-            raise ValueError(f'"dim" ({config.model.dim}) must be divisible by "n_heads" ({config.model.n_heads})')
-        if config.model.n_kv_heads > config.model.n_heads:
-            raise ValueError(f'"n_kv_heads" ({config.model.n_kv_heads}) must be less or equal to "n_heads" ({config.model.n_heads})')
-        if config.model.n_heads % config.model.n_kv_heads != 0:
-            raise ValueError(f'"n_heads" ({config.model.n_heads}) must be divisible by n_kv_heads" ({config.model.n_kv_heads})')
 
     def setup(self):
         self.setup_global_torch_optimizations()

--- a/models/base.py
+++ b/models/base.py
@@ -1,9 +1,8 @@
-import torch
 import torch.nn as nn
 
-from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from metrics import ModelMetrics
+from config import ModelConfig
 
 
 class BaseModel(nn.Module, ABC):
@@ -14,15 +13,18 @@ class BaseModel(nn.Module, ABC):
         self.vocab_size = vocab_size
         self.ignore_index = ignore_index
 
+    @classmethod
     @abstractmethod
-    def forward(self, *args, **kwargs) -> dict:
-        raise NotImplementedError
+    def validate_config(cls, config: ModelConfig):
+        ...
 
+    @abstractmethod
     def get_input_embeddings(self):
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def get_output_embeddings(self):
-        raise NotImplementedError
+        ...
 
     def get_total_parameters_count(self) -> int:
         return sum(p.numel() for p in self.parameters())
@@ -38,3 +40,7 @@ class BaseModel(nn.Module, ABC):
 
     def collect_metrics(self) -> ModelMetrics:
         return ModelMetrics()
+
+    @abstractmethod
+    def forward(self, *args, **kwargs) -> dict:
+        ...

--- a/models/registry.py
+++ b/models/registry.py
@@ -11,6 +11,8 @@ def build_model(*, config, pad_token_id, vocab_size, ignore_index):
     if model_cls is None:
         raise ValueError(f'Invalid model architecture: {config.architecture}')
 
+    model_cls.validate_config(config)
+
     return model_cls(
         config=config,
         pad_token_id=pad_token_id,

--- a/models/tendril.py
+++ b/models/tendril.py
@@ -368,6 +368,15 @@ class TendrilTransformer(BaseModel):
 
         self.register_buffer('rope_freqs', rope_freqs, persistent=False)
 
+    @classmethod
+    def validate_config(cls, config: ModelConfig):
+        if config.dim % config.n_heads != 0:
+            raise ValueError(f'"dim" ({config.dim}) must be divisible by "n_heads" ({config.n_heads})')
+        if config.n_kv_heads > config.n_heads:
+            raise ValueError(f'"n_kv_heads" ({config.n_kv_heads}) must be less or equal to "n_heads" ({config.n_heads})')
+        if config.n_heads % config.n_kv_heads != 0:
+            raise ValueError(f'"n_heads" ({config.n_heads}) must be divisible by n_kv_heads" ({config.n_kv_heads})')
+
     def get_input_embeddings(self):
         return self.tok_embeddings
 


### PR DESCRIPTION
Resolves #24 

`BaseModel` forces implementation of `validate_config(cls, config: ModelConfig)` which is used by the registry to validate model specific config.