### PR TITLE
Making LoRA architecture aware; Restructuring into adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `examples/` Templates for local setup files like the `.env` secrets file and dataset mix.
 - `inference/` Contains inference related components like KV cache implementation and logic for sampling and text generation.
 - `metrics/` Utilities for metric aggregation.
-- `models/` Contains the model registry, the builder, the base model interface, and model implementations. 
+- `models/` Contains the model registry, the builder and the base model interface.
+  - `adapters/` Contains PEFT adapters.
+    - `lora.py` LoRA module that handles the model modification. Rank, alpha, dropout and target modules can be configured accordingly.
+  - `implementations/` Contains model implementations.
 - `recipes/` Recipe definitions for training and dataset preparation. More will be added here.
   - `recipes/config.py` Defines the recipe schema and recipe loading logic.
   - `recipes/pretraining/`
@@ -100,7 +103,6 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `distillation_utils.py` Logic for distillation loss.
 - `dpo_utils.py` Logic for DPO loss.
 - `logger.py` Simple reusable logger.
-- `lora.py` LoRA module that handles the model modification. Rank, alpha, dropout and target modules can be configured accordingly.
 - `lr_schedulers.py` Stores learning rate schedulers. At the moment, it includes a cosine scheduler.
 - `prepare_datasets.py` Entry point for data downloading and preparation.
 - `test_prompts.json` JSON with the list of input prompts to try during training. The expected keys in the JSON (as provided in the file) are "pretraining", "instruct", "dpo".

--- a/config.py
+++ b/config.py
@@ -139,7 +139,7 @@ class LoRAConfig(BaseModel):
     rank: int = 16
     alpha: int = 8
     dropout: float = 0.05
-    target_modules: list[str] = Field(default_factory=lambda: ['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
+    target_modules: list[str] | None = None
 
 class DistillationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/engine/optim.py
+++ b/engine/optim.py
@@ -4,7 +4,7 @@ import json
 
 from torch.optim import AdamW, Muon
 from dataclasses import dataclass, field
-from lora import is_lora_parameter_name
+from models.adapters.lora import is_lora_parameter_name
 from typing import Literal
 from logger import logger
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -433,28 +433,41 @@ class Trainer:
     def apply_lora_modification(self):
         config = self.config
 
-        if not self.config.lora.target_modules:
-            raise ValueError('"lora.target_modules" cannot be empty.')
-
         supported = self.model.supported_lora_target_modules()
-        requested = set(self.config.lora.target_modules)
-        invalid = requested - supported
-        if invalid:
-            raise ValueError(
-                f'The provided LoRA target modules for {self.config.model.architecture} are invalid: {sorted(invalid)}. '
-                f'Supported target modules are: {sorted(supported)}'
-            )
+        if not supported:
+            raise ValueError(f'Model architecture {self.config.model.architecture} does not expose LoRA target modules.')
+
+        logger.info('\nLoRA Configuration')
+        logger.info('----------------------------------------')
+        if self.config.lora.target_modules is None:
+            target_modules = supported
+            logger.warn(f'LoRA "target_modules" was not specified in the config. Using all supported: {supported}')
+        elif len(self.config.lora.target_modules) == 0:
+            raise ValueError('"lora.target_modules" cannot be empty.')
+        else:
+            requested = set(self.config.lora.target_modules)
+            invalid = requested - supported
+            if invalid:
+                raise ValueError(
+                    f'The provided LoRA target modules for {self.config.model.architecture} are invalid: {sorted(invalid)}. '
+                    f'Supported target modules are: {sorted(supported)}'
+                )
+            target_modules = requested
 
         apply_lora(
             model=self.model,
-            target_modules=config.lora.target_modules,
+            target_modules=target_modules,
             rank=config.lora.rank,
             alpha=config.lora.alpha,
-            dropout=config.lora.dropout,
-            is_master_process=self.distributed_ctx.is_master_process
+            dropout=config.lora.dropout
         )
         # by default we freeze the other parameters
         freeze_non_lora_parameters(self.model)
+
+        logger.info(f'- rank: {config.lora.rank}')
+        logger.info(f'- alpha: {config.lora.alpha}')
+        logger.info(f'- dropout: {config.lora.dropout}')
+        logger.info(f'- target modules: {target_modules}')
 
     def apply_lora_for_checkpoint(self):
         if self.checkpoint_data.is_lora_checkpoint:

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -57,7 +57,7 @@ from checkpoints import (
     load_model_state,
     load_optimizer_state
 )
-from lora import (
+from models.adapters.lora import (
     apply_lora,
     freeze_non_lora_parameters
 )
@@ -432,12 +432,25 @@ class Trainer:
 
     def apply_lora_modification(self):
         config = self.config
+
+        if not self.config.lora.target_modules:
+            raise ValueError('"lora.target_modules" cannot be empty.')
+
+        supported = self.model.supported_lora_target_modules()
+        requested = set(self.config.lora.target_modules)
+        invalid = requested - supported
+        if invalid:
+            raise ValueError(
+                f'The provided LoRA target modules for {self.config.model.architecture} are invalid: {sorted(invalid)}. '
+                f'Supported target modules are: {sorted(supported)}'
+            )
+
         apply_lora(
-            self.model,
+            model=self.model,
+            target_modules=config.lora.target_modules,
             rank=config.lora.rank,
             alpha=config.lora.alpha,
             dropout=config.lora.dropout,
-            target_modules=config.lora.target_modules,
             is_master_process=self.distributed_ctx.is_master_process
         )
         # by default we freeze the other parameters

--- a/models/adapters/lora.py
+++ b/models/adapters/lora.py
@@ -35,9 +35,10 @@ def model_has_lora(model):
     return any(isinstance(m, CustomLoRA) for m in model.modules())
 
 def apply_lora(
+    *,
     model,
+    target_modules,
     device='cpu',
-    target_modules=('wq', 'wk', 'wv', 'wo', 'w1', 'w3'),
     rank=16,
     alpha=8,
     dropout=0.0,

--- a/models/adapters/lora.py
+++ b/models/adapters/lora.py
@@ -3,7 +3,6 @@ import torch
 import torch.nn.functional as F
 
 from torch import nn
-from logger import logger
 
 
 class CustomLoRA(nn.Module):
@@ -41,17 +40,9 @@ def apply_lora(
     device='cpu',
     rank=16,
     alpha=8,
-    dropout=0.0,
-    is_master_process=True
+    dropout=0.0
 ):
     if model_has_lora(model):
-        if is_master_process:
-            logger.info('\nLoRA Configuration')
-            logger.info('----------------------------------------')
-            logger.info('LoRA is already applied with params:')
-            logger.info(f'- rank: {rank}')
-            logger.info(f'- alpha: {alpha}')
-            logger.info(f'- dropout: {dropout}')
         return
 
     for name, module in model.named_modules():
@@ -66,13 +57,6 @@ def apply_lora(
                 child_name,
                 lora_layer
             )
-    if is_master_process:
-        logger.info('\nLoRA Configuration')
-        logger.info('----------------------------------------')
-        logger.info('LoRA applied with params:')
-        logger.info(f'- rank: {rank}')
-        logger.info(f'- alpha: {alpha}')
-        logger.info(f'- dropout: {dropout}')
 
 def is_lora_parameter_name(name):
     return name.endswith('.A') or name.endswith('.B')

--- a/models/base.py
+++ b/models/base.py
@@ -18,6 +18,10 @@ class BaseModel(nn.Module, ABC):
     def validate_config(cls, config: ModelConfig):
         ...
 
+    @classmethod
+    def supported_lora_target_modules(cls) -> set[str]:
+        return set()
+
     @abstractmethod
     def get_input_embeddings(self):
         ...

--- a/models/implementations/tendril.py
+++ b/models/implementations/tendril.py
@@ -238,6 +238,10 @@ class TendrilTransformer(BaseModel):
         if config.n_heads % config.n_kv_heads != 0:
             raise ValueError(f'"n_heads" ({config.n_heads}) must be divisible by "n_kv_heads" ({config.n_kv_heads})')
 
+    @classmethod
+    def supported_lora_target_modules(cls) -> set[str]:
+        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
+
     def get_input_embeddings(self):
         return self.tok_embeddings
 

--- a/models/implementations/tendril.py
+++ b/models/implementations/tendril.py
@@ -240,7 +240,7 @@ class TendrilTransformer(BaseModel):
 
     @classmethod
     def supported_lora_target_modules(cls) -> set[str]:
-        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
+        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w2', 'w3'])
 
     def get_input_embeddings(self):
         return self.tok_embeddings

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -378,7 +378,7 @@ class TendrilMoETransformer(BaseModel):
 
     @classmethod
     def supported_lora_target_modules(cls) -> set[str]:
-        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
+        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w2', 'w3'])
 
     def get_input_embeddings(self):
         return self.tok_embeddings

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -376,6 +376,10 @@ class TendrilMoETransformer(BaseModel):
         if config.moe.z_loss_coef < 0:
             raise ValueError('"moe.z_loss_coef" must be >= 0')
 
+    @classmethod
+    def supported_lora_target_modules(cls) -> set[str]:
+        return set(['wq', 'wk', 'wv', 'wo', 'w1', 'w3'])
+
     def get_input_embeddings(self):
         return self.tok_embeddings
 


### PR DESCRIPTION
Resolves #31 

Changes:
- Target modules are now required to be exposed via a class method as defined in the `BaseModel` class.
- Any PEFT related adapters will now live in`models/adapters/`