### PR TITLE
Mechanism for snapshot creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ env/
 *.pth
 datasets/
 checkpoints/
+snapshots/
 wandb/
 
 # Local dataset mix recipes

--- a/config.py
+++ b/config.py
@@ -113,12 +113,17 @@ class CheckpointPathsConfig(BaseModel):
     load_file_path: str | None = None
     save_dir_path: str = './checkpoints'
 
+class SnapshotPathsConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    save_dir_path: str = './snapshots'
+
 class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     datasets: DatasetPathsConfig = Field(default_factory=DatasetPathsConfig)
     evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
     test_prompts_path: str = './test_prompts.json'
     checkpoints: CheckpointPathsConfig = Field(default_factory=CheckpointPathsConfig)
+    snapshots: SnapshotPathsConfig = Field(default_factory=SnapshotPathsConfig)
 
 class GenerationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -205,6 +210,10 @@ class CheckpointingConfig(BaseModel):
     run_on_first_step: bool = False
     run_on_last_step: bool = False
 
+class SnapshotConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    name: str | None = None
+
 class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     third_party: ThirdPartyConfig = Field(default_factory=ThirdPartyConfig)
@@ -225,6 +234,7 @@ class GlobalConfig(BaseModel):
     torch_profiler: TorchProfilerConfig = Field(default_factory=TorchProfilerConfig)
     validation: ValidationConfig = Field(default_factory=ValidationConfig)
     checkpointing: CheckpointingConfig = Field(default_factory=CheckpointingConfig)
+    snapshot: SnapshotConfig = Field(default_factory=SnapshotConfig)
 
     def model_post_init(self, __context: Any) -> None:
         # Sets default paths for huggingface

--- a/engine/snapshot.py
+++ b/engine/snapshot.py
@@ -1,0 +1,69 @@
+import json
+import re
+import subprocess
+
+from datetime import datetime, timezone
+from pathlib import Path
+from importlib.metadata import version
+from logger import logger
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+def clean_name(name):
+    return re.sub(r'[^a-zA-Z0-9._-]+', '_', name).strip('_').lower()
+
+def generate_timestamp():
+    return datetime.now(timezone.utc)
+
+def generate_snapshot_name(timestamp, name=None):
+    timestamp_str = timestamp.strftime('%Y%m%d_%H%M%S_UTC')
+    if not name:
+        return timestamp_str
+    return f'{timestamp_str}_{clean_name(name)}'
+
+def git_commit_hash():
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=PROJECT_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        return None
+
+def get_packages_versions():
+    requirements = (PROJECT_ROOT / 'requirements.txt').read_text().splitlines()
+    valid_requirements = [req.strip() for req in requirements if req.strip() and not req.strip().startswith('#')]
+    package_versions = []
+    for package in valid_requirements:
+        try:
+            resolved = f'{package}=={version(package)}'
+        except Exception:
+            resolved = f'{package}==UNKNOWN'
+        package_versions.append(resolved)
+
+    return package_versions
+
+def create_run_snapshot(*, args, workload_summary, name, save_dir_path):
+    timestamp = generate_timestamp()
+    snapshot_name = generate_snapshot_name(timestamp, name)
+    snapshot_dir = Path(save_dir_path)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = snapshot_dir / f'{snapshot_name}.json'
+
+    snapshot = {
+        'snapshot_name': snapshot_name,
+        'snapshot_path': str(snapshot_path),
+        'created_at_utc': timestamp.isoformat(),
+        'args': vars(args),
+        'git_commit_hash': git_commit_hash(),
+        'requirements': get_packages_versions(),
+        'workload_summary': workload_summary
+    }
+
+    snapshot_json = json.dumps(snapshot, indent=2, default=str)
+    snapshot_path.write_text(snapshot_json, encoding='utf-8')
+
+    logger.info(f'Snapshot saved to: {snapshot_path}')

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -37,6 +37,7 @@ from engine.logging import (
 from engine.torch_profiler import (
     init_torch_profiler_context
 )
+from engine.snapshot import create_run_snapshot
 from ddp_utils import (
     init_multi_gpu,
     prepare_model_for_ddp,
@@ -133,6 +134,7 @@ class Trainer:
         self.prepare_runtime()
         self.prepare_workload_summary_json()
         self.log_workload_summary()
+        self.save_run_snapshot()
         self.check_all_devices_ready()
         self.setup_wandb()
         self.setup_torch_profiler()
@@ -582,6 +584,15 @@ class Trainer:
             logger.info('--------------------------------------------------------')
             logger.info(self.workload_summary, is_json=True)
             logger.info('--------------------------------------------------------')
+
+    def save_run_snapshot(self):
+        if self.distributed_ctx.is_master_process:
+            create_run_snapshot(
+                args=self.args,
+                workload_summary=self.workload_summary,
+                name=self.config.snapshot.name,
+                save_dir_path=self.config.paths.snapshots.save_dir_path
+            )
 
     def setup_wandb(self):
         self.wandb = WandbWrapper(


### PR DESCRIPTION
resolves #34 

Adds a mechanism to create a snapshot before the training starts.

Snapshot is created as a .json file and for now includes the following properties:
- `snapshot_name`
- `snapshot_path`
- `created_at_utc`
- `args`
- `git_commit_hash`
- `requirements` (this is the packages and current versions)
- `workload_summary` (workload summary as already logged in the console)