### PR TITLE
Common output path for runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ datasets/
 checkpoints/
 snapshots/
 wandb/
+runs/
 
 # Local dataset mix recipes
 *.local.json

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
   - `HFTokenizer`: loads a tokenizer from Hugging Face via `AutoTokenizer.from_pretrained(...)` and aligns the required special tokens (`bos`, `eos`, headers, `eot`, `pad`).
   - `init_tokenizer(...)` selects the backend based on `config.tokenizer.huggingface_tokenizer`.
 - `train.py` Entry point for training runs.
+- `utils.py` Common generic logic that can be reused in different components.
 - `wandb_utils.py` A wrapper for Weights & Biases.
   - Weights & Biases [here](https://wandb.ai/site/)
 
@@ -151,7 +152,7 @@ The main sections are:
 - `model`: model architecture and model-specific settings
 - `training`: stage, seed, total batch size, max steps, early stopping
 - `optimizers`: AdamW and optional Muon configuration
-- `paths`: dataset, evaluation, checkpoint, and prompt paths
+- `paths`: dataset, evaluation, runs, and prompt paths
 - `validation`: validation frequency and number of validation steps
 - `evals`: HellaSwag, WinoGrande, and ARC-Challenge settings
 - `generation`: text generation frequency and max generation length
@@ -184,7 +185,7 @@ HF_HOME='./cache'
   --start-step <N>                  # Override internal step counter
 ```
 **NOTES:**
-  - The checkpoint paths are configured in `config.py` under `GlobalConfig.paths.checkpoints`.
+  - The project output path can be configured in `config.py` under `GlobalConfig.paths.runs`. By default it will use `./runs`
   - When using `--recipe`, the recipe defines the training stage. The flags `--pretraining`, `--instruct`, and `--dpo` cannot be combined with `--recipe`.
 
 Example recipe commands:

--- a/config.py
+++ b/config.py
@@ -181,7 +181,7 @@ class WandbConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     enabled: bool = False
     project_name: str = 'gradient-garden'
-    run_name: str = 'debug'
+    run_name: str | None = None
 
 class TorchProfilerConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -208,10 +208,6 @@ class CheckpointingConfig(BaseModel):
     run_on_first_step: bool = False
     run_on_last_step: bool = False
 
-class SnapshotConfig(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-    name: str | None = None
-
 class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     run: RunConfig = Field(default_factory=RunConfig)
@@ -233,7 +229,6 @@ class GlobalConfig(BaseModel):
     torch_profiler: TorchProfilerConfig = Field(default_factory=TorchProfilerConfig)
     validation: ValidationConfig = Field(default_factory=ValidationConfig)
     checkpointing: CheckpointingConfig = Field(default_factory=CheckpointingConfig)
-    snapshot: SnapshotConfig = Field(default_factory=SnapshotConfig)
 
     def model_post_init(self, __context: Any) -> None:
         # Sets default paths for huggingface

--- a/config.py
+++ b/config.py
@@ -22,6 +22,10 @@ class TrainingPrecision(str, Enum):
     FP16 = 'fp16'
     FP32 = 'fp32'
 
+class RunConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    name: str | None = None
+
 class ThirdPartyConfig(BaseSettings):
     model_config = ConfigDict(env_file='.env', extra='ignore')
     wandb_api_key: Annotated[str | None, Field(alias='WANDB_API_KEY', exclude=True)] = None
@@ -108,22 +112,16 @@ class EvalPathsConfig(BaseModel):
     winogrande_path: str = './datasets/winogrande'
     arc_challenge_path: str = './datasets/arc_challenge'
 
-class CheckpointPathsConfig(BaseModel):
+class RunPathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    load_file_path: str | None = None
-    save_dir_path: str = './checkpoints'
-
-class SnapshotPathsConfig(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-    save_dir_path: str = './snapshots'
+    output_dir_path: str = './runs'
 
 class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     datasets: DatasetPathsConfig = Field(default_factory=DatasetPathsConfig)
     evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
+    run: RunPathsConfig = Field(default_factory=RunPathsConfig)
     test_prompts_path: str = './test_prompts.json'
-    checkpoints: CheckpointPathsConfig = Field(default_factory=CheckpointPathsConfig)
-    snapshots: SnapshotPathsConfig = Field(default_factory=SnapshotPathsConfig)
 
 class GenerationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -216,6 +214,7 @@ class SnapshotConfig(BaseModel):
 
 class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
+    run: RunConfig = Field(default_factory=RunConfig)
     third_party: ThirdPartyConfig = Field(default_factory=ThirdPartyConfig)
     data_preparation: DatasetPreparationConfig = Field(default_factory=DatasetPreparationConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)

--- a/config.py
+++ b/config.py
@@ -120,7 +120,7 @@ class PathsConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     datasets: DatasetPathsConfig = Field(default_factory=DatasetPathsConfig)
     evals: EvalPathsConfig = Field(default_factory=EvalPathsConfig)
-    run: RunPathsConfig = Field(default_factory=RunPathsConfig)
+    runs: RunPathsConfig = Field(default_factory=RunPathsConfig)
     test_prompts_path: str = './test_prompts.json'
 
 class GenerationConfig(BaseModel):

--- a/engine/context.py
+++ b/engine/context.py
@@ -3,6 +3,7 @@ import torch
 from dataclasses import dataclass, asdict
 from typing import Any
 from torch.distributed.fsdp import MixedPrecisionPolicy
+from datetime import datetime
 
 
 @dataclass(frozen=True)
@@ -56,3 +57,8 @@ class TrainerContext:
 
     def __repr__(self):
         return json.dumps(self.to_dict(), indent=4)
+
+@dataclass(frozen=True)
+class RunContext:
+    name: str
+    timestamp: datetime

--- a/engine/snapshot.py
+++ b/engine/snapshot.py
@@ -1,26 +1,13 @@
 import json
-import re
 import subprocess
 
-from datetime import datetime, timezone
 from pathlib import Path
 from importlib.metadata import version
 from logger import logger
+from utils import generate_run_name
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-
-def clean_name(name):
-    return re.sub(r'[^a-zA-Z0-9._-]+', '_', name).strip('_').lower()
-
-def generate_timestamp():
-    return datetime.now(timezone.utc)
-
-def generate_snapshot_name(timestamp, name=None):
-    timestamp_str = timestamp.strftime('%Y%m%d_%H%M%S_UTC')
-    if not name:
-        return timestamp_str
-    return f'{timestamp_str}_{clean_name(name)}'
 
 def git_commit_hash():
     try:
@@ -47,8 +34,8 @@ def get_packages_versions():
     return package_versions
 
 def create_run_snapshot(*, args, workload_summary, name, save_dir_path):
-    timestamp = generate_timestamp()
-    snapshot_name = generate_snapshot_name(timestamp, name)
+    snapshot_name, timestamp = generate_run_name(name=name)
+
     snapshot_dir = Path(save_dir_path)
     snapshot_dir.mkdir(parents=True, exist_ok=True)
     snapshot_path = snapshot_dir / f'{snapshot_name}.json'

--- a/engine/snapshot.py
+++ b/engine/snapshot.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from importlib.metadata import version
 from logger import logger
-from utils import generate_run_name
+from engine.context import RunContext
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -33,8 +33,9 @@ def get_packages_versions():
 
     return package_versions
 
-def create_run_snapshot(*, args, workload_summary, name, save_dir_path):
-    snapshot_name, timestamp = generate_run_name(name=name)
+def create_run_snapshot(*, run_ctx: RunContext, args, workload_summary, save_dir_path):
+    snapshot_name = run_ctx.name
+    timestamp = run_ctx.timestamp
 
     snapshot_dir = Path(save_dir_path)
     snapshot_dir.mkdir(parents=True, exist_ok=True)

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -267,7 +267,7 @@ class Trainer:
         )
 
     def build_run_context(self):
-        run_name, timestamp = generate_run_name(name=self.config.runs.name)
+        run_name, timestamp = generate_run_name(name=self.config.run.name)
         self.run_ctx = RunContext(
             name=run_name,
             timestamp=timestamp

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -16,7 +16,8 @@ from engine.context import (
     DistributedContext,
     DeviceContext,
     PrecisionContext,
-    TrainerContext
+    TrainerContext,
+    RunContext
 )
 from engine.core import (
     TrainerState
@@ -80,6 +81,8 @@ from evals import (
     load_multiple_choice_eval_file,
     estimate_best_candidate_index_from_logits
 )
+from utils import generate_run_name
+from pathlib import Path
 
 
 class Trainer:
@@ -91,6 +94,7 @@ class Trainer:
         self.device_ctx = None
         self.precision_ctx = None
         self.trainer_ctx = None
+        self.run_ctx = None
         self.hellaswag_data = None
         self.winogrande_data = None
         self.arc_challenge_data = None
@@ -148,6 +152,7 @@ class Trainer:
         self.build_device_context(device)
         self.build_precision_context()
         self.build_trainer_context()
+        self.build_run_context()
 
     def load_eval_assets(self):
         self.load_hellaswag_eval_data()
@@ -261,6 +266,13 @@ class Trainer:
             grad_accum_steps=self.compute_grad_accum_steps(self.distributed_ctx.ddp_world_size)
         )
 
+    def build_run_context(self):
+        run_name, timestamp = generate_run_name(name=self.config.run.name)
+        self.run_ctx = RunContext(
+            name=run_name,
+            timestamp=timestamp
+        )
+
     def load_test_generation_prompts(self):
         if not self.can_run_scheduled_action(self.config.generation):
             return
@@ -367,12 +379,10 @@ class Trainer:
         )
 
     def resolve_checkpoint_request(self):
-        checkpoint_file_path = self.args.checkpoint or self.config.paths.checkpoints.load_file_path
-
-        if checkpoint_file_path is None:
+        if self.args.checkpoint is None:
             return None
 
-        checkpoint_file_path = Path(checkpoint_file_path)
+        checkpoint_file_path = Path(self.args.checkpoint)
 
         if not checkpoint_file_path.exists():
             raise FileNotFoundError(f'Checkpoint file does not exist: {checkpoint_file_path}')
@@ -585,13 +595,22 @@ class Trainer:
             logger.info(self.workload_summary, is_json=True)
             logger.info('--------------------------------------------------------')
 
+    def get_run_output_dir_path(self):
+        return Path(self.config.paths.run.output_dir_path) / self.run_ctx.name
+
+    def get_checkpoints_dir_path(self):
+        return self.get_run_output_dir_path() / 'checkpoints'
+
+    def get_snapshots_dir_path(self):
+        return self.get_run_output_dir_path() / 'snapshots'
+
     def save_run_snapshot(self):
         if self.distributed_ctx.is_master_process:
             create_run_snapshot(
                 args=self.args,
                 workload_summary=self.workload_summary,
                 name=self.config.snapshot.name,
-                save_dir_path=self.config.paths.snapshots.save_dir_path
+                save_dir_path=self.get_snapshots_dir_path()
             )
 
     def setup_wandb(self):
@@ -602,8 +621,9 @@ class Trainer:
         )
         self.wandb.init(
             self.config.wandb.project_name,
-            job_name=self.config.wandb.run_name,
-            config=self.workload_summary
+            job_name=self.config.wandb.run_name if self.config.wandb.run_name else self.run_ctx.name,
+            config=self.workload_summary,
+            output_path=self.get_run_output_dir_path()
         )
 
     def setup_torch_profiler(self):
@@ -910,7 +930,7 @@ class Trainer:
         )
 
     def get_save_checkpoints_path(self):
-        checkpoint_save_path = self.config.paths.checkpoints.save_dir_path
+        checkpoint_save_path = self.get_checkpoints_dir_path()
 
         if checkpoint_save_path is None:
             raise ValueError('Checkpoint save dir path must be set in the configuration: "config.paths.checkpoints.save_dir_path"')

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -267,7 +267,7 @@ class Trainer:
         )
 
     def build_run_context(self):
-        run_name, timestamp = generate_run_name(name=self.config.run.name)
+        run_name, timestamp = generate_run_name(name=self.config.runs.name)
         self.run_ctx = RunContext(
             name=run_name,
             timestamp=timestamp
@@ -596,7 +596,7 @@ class Trainer:
             logger.info('--------------------------------------------------------')
 
     def get_run_output_dir_path(self):
-        return Path(self.config.paths.run.output_dir_path) / self.run_ctx.name
+        return Path(self.config.paths.runs.output_dir_path) / self.run_ctx.name
 
     def get_checkpoints_dir_path(self):
         return self.get_run_output_dir_path() / 'checkpoints'

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -596,7 +596,7 @@ class Trainer:
             logger.info('--------------------------------------------------------')
 
     def get_run_output_dir_path(self):
-        return Path(self.config.paths.runs.output_dir_path) / self.run_ctx.name
+        return Path(self.config.paths.runs.output_dir_path) / self.config.training.stage.value / self.run_ctx.name
 
     def get_checkpoints_dir_path(self):
         return self.get_run_output_dir_path() / 'checkpoints'

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -607,9 +607,9 @@ class Trainer:
     def save_run_snapshot(self):
         if self.distributed_ctx.is_master_process:
             create_run_snapshot(
+                run_ctx=self.run_ctx,
                 args=self.args,
                 workload_summary=self.workload_summary,
-                name=self.config.snapshot.name,
                 save_dir_path=self.get_snapshots_dir_path()
             )
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -82,7 +82,6 @@ from evals import (
     estimate_best_candidate_index_from_logits
 )
 from utils import generate_run_name
-from pathlib import Path
 
 
 class Trainer:
@@ -267,10 +266,21 @@ class Trainer:
         )
 
     def build_run_context(self):
-        run_name, timestamp = generate_run_name(name=self.config.run.name)
+        dist_buffer = [None]
+
+        if self.distributed_ctx.is_master_process:
+            name, timestamp = generate_run_name(name=self.config.run.name)
+            dist_buffer[0] = {
+                'name': name,
+                'timestamp': timestamp
+            }
+
+        if self.distributed_ctx.ddp and dist.is_initialized():
+            dist.broadcast_object_list(dist_buffer, src=0)
+
         self.run_ctx = RunContext(
-            name=run_name,
-            timestamp=timestamp
+            name=dist_buffer[0]['name'],
+            timestamp=dist_buffer[0]['timestamp']
         )
 
     def load_test_generation_prompts(self):
@@ -929,14 +939,6 @@ class Trainer:
             pbar=pbar
         )
 
-    def get_save_checkpoints_path(self):
-        checkpoint_save_path = self.get_checkpoints_dir_path()
-
-        if checkpoint_save_path is None:
-            raise ValueError('Checkpoint save dir path must be set in the configuration: "config.paths.checkpoints.save_dir_path"')
-
-        return checkpoint_save_path
-
     def run_save_checkpoint(self, pbar=None):
         if (
             not self.config.checkpointing.save_checkpoints or
@@ -946,7 +948,7 @@ class Trainer:
 
         logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
         save_checkpoint(
-            self.get_save_checkpoints_path(),
+            self.get_checkpoints_dir_path(),
             get_model(self.model),
             self.config,
             self.trainer_state.current_step,

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -2,6 +2,9 @@ name: debug_dpo
 description: Small DPO recipe for smoke tests.
 
 config:
+  run:
+    name: debug_dpo
+
   runtime:
     device_type: cuda
     training_precision: bf16
@@ -41,8 +44,8 @@ config:
   paths:
     datasets:
       dpo_path: ./datasets/debug/dpo
-    checkpoints:
-      save_dir_path: ./checkpoints/debug/dpo
+    run:
+      output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -44,7 +44,7 @@ config:
   paths:
     datasets:
       dpo_path: ./datasets/debug/dpo
-    run:
+    runs:
       output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -2,6 +2,9 @@ name: debug_instruct
 description: Small instruct tuning recipe for smoke tests.
 
 config:
+  run:
+    name: debug_instruct
+
   runtime:
     device_type: cuda
     training_precision: bf16
@@ -41,8 +44,8 @@ config:
   paths:
     datasets:
       instruct_path: ./datasets/debug/instruct
-    checkpoints:
-      save_dir_path: ./checkpoints/debug/instruct
+    run:
+      output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -44,7 +44,7 @@ config:
   paths:
     datasets:
       instruct_path: ./datasets/debug/instruct
-    run:
+    runs:
       output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -45,7 +45,7 @@ config:
       hellaswag_path: ./datasets/debug/hellaswag
       winogrande_path: ./datasets/debug/winogrande
       arc_challenge_path: ./datasets/debug/arc_challenge
-    run:
+    runs:
       output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -2,6 +2,9 @@ name: debug_pretraining
 description: Small pretraining recipe for smoke tests.
 
 config:
+  run:
+    name: debug_pretraining
+
   runtime:
     device_type: cuda
     training_precision: bf16
@@ -42,8 +45,8 @@ config:
       hellaswag_path: ./datasets/debug/hellaswag
       winogrande_path: ./datasets/debug/winogrande
       arc_challenge_path: ./datasets/debug/arc_challenge
-    checkpoints:
-      save_dir_path: ./checkpoints/debug/pretraining
+    run:
+      output_dir_path: ./runs
     test_prompts_path: ./test_prompts.json
 
   optimizers:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,18 @@
+import re
+
+from datetime import datetime, timezone
+
+
+def clean_name(name):
+    return re.sub(r'[^a-zA-Z0-9._-]+', '_', name).strip('_').lower()
+
+def generate_timestamp():
+    return datetime.now(timezone.utc)
+
+def generate_run_name(timestamp=None, name=None) -> dict:
+    if timestamp is None:
+        timestamp = generate_timestamp()
+    timestamp_str = timestamp.strftime('%Y%m%d_%H%M%S_UTC')
+    if not name:
+        return timestamp_str, timestamp
+    return f'{timestamp_str}_{clean_name(name)}', timestamp

--- a/wandb_utils.py
+++ b/wandb_utils.py
@@ -15,7 +15,7 @@ class WandbWrapper():
                 self.WANDB = True
                 logger.info('Wandb enabled.')
 
-    def init(self, project_name, *, job_name=None, config=None):
+    def init(self, project_name, *, job_name=None, config=None, output_path=None):
         if not self.WANDB:
             return
         
@@ -23,14 +23,12 @@ class WandbWrapper():
             job_start_time = datetime.now().strftime('%Y-%m-%d %H:%M')
             job_name = f'run_{job_start_time}'
 
-        if config is None:
-            wandb.init(project=project_name, name=job_name)
-        else:
-            wandb.init(
-                project=project_name,
-                name=job_name,
-                config=config
-            )
+        wandb.init(
+            project=project_name,
+            name=job_name,
+            config=config,
+            dir=output_path
+        )
 
     def log(self, data):
         if not self.WANDB:


### PR DESCRIPTION
Resolves #37 

Modifications:
- All artifacts will be created inside a folder defined in `config.paths.run.output_dir_path`, default is `./runs`;
- `config.run.name` added as optional param for the default run name;
- Added `utils.py` for common tools ;
- Trainer will generate a run name by default that is used in both snapshots / wandb. Note that wandb run name can be changed as before if the property is defined;
- Removed snapshot config (only had name before). Name is now set to the main run name.