### PR TITLE
Improved abstraction in the tokenizer base; Some rework in DPO to take advantage of the changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ class ThirdPartyConfig(BaseSettings):
     model_config = ConfigDict(env_file='.env', extra='ignore')
     wandb_api_key: Annotated[str | None, Field(alias='WANDB_API_KEY', exclude=True)] = None
     hf_token: Annotated[str | None, Field(alias='HF_TOKEN', exclude=True)] = None
-    hf_home: str = Field(default='./cache', alias='HF_HOME')
+    hf_home: str = Field(default=str(Path.cwd() / 'cache'), alias='HF_HOME')
 
 class DatasetPreparationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -70,25 +70,30 @@ def ensure_user_first(conversation):
 
 tokenizer = None
 
-def tokenize(tokenizer_kwargs, system_prompt, doc):
+def tokenize(tokenizer_kwargs, ignore_index, doc):
     global tokenizer
     if tokenizer is None:
         tokenizer = init_tokenizer(**tokenizer_kwargs)
 
-    prompt_tokens, chosen_tokens, rejected_tokens = tokenizer.encode_chat_dpo(
+    (
+        prompt_input_ids,
+        chosen_input_ids,
+        chosen_labels,
+        rejected_input_ids,
+        rejected_labels
+    ) = tokenizer.encode_instruct_chat_dpo(
         conversation=doc['prompt'],
         chosen=doc['chosen'],
-        rejected=doc['rejected']
+        rejected=doc['rejected'],
+        ignore_index=ignore_index
     )
 
-    prompt_input_ids = np.array(prompt_tokens, dtype=np.uint32)
-    chosen_input_ids = np.array(chosen_tokens, dtype=np.uint32)
-    rejected_input_ids = np.array(rejected_tokens, dtype=np.uint32)
-
-    return { 
-        'prompt_input_ids': prompt_input_ids,
-        'chosen_input_ids': chosen_input_ids,
-        'rejected_input_ids': rejected_input_ids 
+    return {
+        'prompt_input_ids': np.array(prompt_input_ids, dtype=np.uint32),
+        'chosen_input_ids': np.array(chosen_input_ids, dtype=np.uint32),
+        'chosen_labels': np.array(chosen_labels, dtype=np.int64),
+        'rejected_input_ids': np.array(rejected_input_ids, dtype=np.uint32),
+        'rejected_labels': np.array(rejected_labels, dtype=np.int64),
     }
 
 def download_and_prepare_data(
@@ -149,7 +154,7 @@ def download_and_prepare_data(
             partial(
                 tokenize,
                 tokenizer_kwargs,
-                config.prompts.system_prompt
+                config.tokenizer.ignore_index
             ),
             num_proc=num_proc,
             remove_columns=columns_to_remove

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -104,7 +104,7 @@ def tokenize(tokenizer_kwargs, ignore_index, doc):
     if tokenizer is None:
         tokenizer = init_tokenizer(**tokenizer_kwargs)
 
-    tokens, labels = tokenizer.encode_chat(
+    tokens, labels = tokenizer.encode_instruct_chat(
         conversation=doc['conversation'],
         ignore_index=ignore_index
     )

--- a/engine/dataloaders.py
+++ b/engine/dataloaders.py
@@ -343,7 +343,8 @@ class DirectPreferenceOptimizationDataLoader:
         use_shuffle,
         pad_id,
         drop_last,
-        number_of_cpu_processes
+        number_of_cpu_processes,
+        ignore_index
     ):
         self.B = batch_size
         self.S = sequence_length
@@ -352,6 +353,7 @@ class DirectPreferenceOptimizationDataLoader:
         self.ddp_world_size = ddp_world_size
         self.total_tokens = None
         self.number_of_cpu_processes = number_of_cpu_processes
+        self.ignore_index = ignore_index
 
         dataset = datasets.load_from_disk(os.path.join(data_root, split))
         logger.info(f'found {len(dataset)} examples for {split}')
@@ -369,60 +371,87 @@ class DirectPreferenceOptimizationDataLoader:
         )
 
         def collate(examples):
-            prompts = []
-            chosens = []
-            rejecteds = []
+            chosen_ids = []
+            chosen_labels = []
+            rejected_ids = []
+            rejected_labels = []
 
             for i, e in enumerate(examples):
-                prompt = torch.tensor(e['prompt_input_ids'], dtype=torch.long)
-                chosen = torch.tensor(e['chosen_input_ids'], dtype=torch.long)
-                rejected = torch.tensor(e['rejected_input_ids'], dtype=torch.long)
+                chosen_input_ids = torch.tensor(e['chosen_input_ids'], dtype=torch.long)
+                chosen_target_labels = torch.tensor(e['chosen_labels'], dtype=torch.long)
+                rejected_input_ids = torch.tensor(e['rejected_input_ids'], dtype=torch.long)
+                rejected_target_labels = torch.tensor(e['rejected_labels'], dtype=torch.long)
 
-                if prompt.numel() == 0:
-                    raise ValueError(f'Empty prompt_input_ids in collate example {i}: {e}')
-                if chosen.numel() == 0:
+                if chosen_input_ids.numel() == 0:
                     raise ValueError(f'Empty chosen_input_ids in collate example {i}: {e}')
-                if rejected.numel() == 0:
-                    raise ValueError(f'Empty rejected in collate example {i}: {e}')
+                if chosen_target_labels.numel() == 0:
+                    raise ValueError(f'Empty chosen_labels in collate example {i}: {e}')
+                if rejected_input_ids.numel() == 0:
+                    raise ValueError(f'Empty rejected_input_ids in collate example {i}: {e}')
+                if rejected_target_labels.numel() == 0:
+                    raise ValueError(f'Empty rejected_labels in collate example {i}: {e}')
+                if chosen_input_ids.numel() != chosen_target_labels.numel():
+                    raise ValueError(
+                        f'chosen input_ids/labels length do not match in collate example {i}: '
+                        f'{chosen_input_ids.numel()} vs {chosen_target_labels.numel()}'
+                    )
+                if rejected_input_ids.numel() != rejected_target_labels.numel():
+                    raise ValueError(
+                        f'rejected input_ids/labels length do not match in collate example {i}: '
+                        f'{rejected_input_ids.numel()} vs {rejected_target_labels.numel()}'
+                    )
+                if (chosen_target_labels != self.ignore_index).sum().item() == 0:
+                    raise ValueError(f'No chosen labels before truncation in collate example {i}: {e}')
+                if (rejected_target_labels != self.ignore_index).sum().item() == 0:
+                    raise ValueError(f'No rejected labels before truncation in collate example {i}: {e}')
 
-                if prompt.numel() > sequence_length:
-                    prompt = prompt[-sequence_length:]
-                if chosen.numel() > sequence_length:
-                    chosen = chosen[-sequence_length:]
-                if rejected.numel() > sequence_length:
-                    rejected = rejected[-sequence_length:]
+                if chosen_input_ids.numel() > sequence_length:
+                    chosen_input_ids = chosen_input_ids[-sequence_length:]
+                    chosen_target_labels = chosen_target_labels[-sequence_length:]
+                if rejected_input_ids.numel() > sequence_length:
+                    rejected_input_ids = rejected_input_ids[-sequence_length:]
+                    rejected_target_labels = rejected_target_labels[-sequence_length:]
 
-                if (prompt != int(pad_id)).sum().item() == 0:
-                    raise ValueError(f'The prompt after truncation is all pad tokens in collate example {i}: {e}')
-                if (chosen != int(pad_id)).sum().item() == 0:
-                    raise ValueError(f'The chosen after truncation is all pad tokens in collate example {i}: {e}')
-                if (rejected != int(pad_id)).sum().item() == 0:
-                    raise ValueError(f'The rejected after truncation is all pad tokens in collate example {i}: {e}')
+                if (chosen_input_ids != int(pad_id)).sum().item() == 0:
+                    raise ValueError(f'Chosen input ids after truncation are all pad tokens in collate example {i}: {e}')
+                if (rejected_input_ids != int(pad_id)).sum().item() == 0:
+                    raise ValueError(f'Rejected input ids after truncation are all pad tokens in collate example {i}: {e}')
+                if (chosen_target_labels != self.ignore_index).sum().item() == 0:
+                    raise ValueError(f'No chosen labels after truncation in collate example {i}: {e}')
+                if (rejected_target_labels != self.ignore_index).sum().item() == 0:
+                    raise ValueError(f'No rejected labels after truncation in collate example {i}: {e}')
 
-                prompts.append(prompt)
-                chosens.append(chosen)
-                rejecteds.append(rejected)
+                chosen_ids.append(chosen_input_ids)
+                chosen_labels.append(chosen_target_labels)
+                rejected_ids.append(rejected_input_ids)
+                rejected_labels.append(rejected_target_labels)
 
-            prompt_padded = pad_batch_to_multiple_of(
-                sequences=prompts,
+            chosen_ids = pad_batch_to_multiple_of(
+                sequences=chosen_ids,
                 padding_value=int(pad_id),
                 multiple=8,
                 max_length=sequence_length,
             )
-            chosen_padded = pad_batch_to_multiple_of(
-                sequences=chosens,
+            chosen_labels = pad_batch_to_multiple_of(
+                sequences=chosen_labels,
+                padding_value=self.ignore_index,
+                multiple=8,
+                max_length=sequence_length,
+            )
+            rejected_ids = pad_batch_to_multiple_of(
+                sequences=rejected_ids,
                 padding_value=int(pad_id),
                 multiple=8,
                 max_length=sequence_length,
             )
-            rejected_padded = pad_batch_to_multiple_of(
-                sequences=rejecteds,
-                padding_value=int(pad_id),
+            rejected_labels = pad_batch_to_multiple_of(
+                sequences=rejected_labels,
+                padding_value=self.ignore_index,
                 multiple=8,
                 max_length=sequence_length,
             )
 
-            return prompt_padded, chosen_padded, rejected_padded
+            return chosen_ids, chosen_labels, rejected_ids, rejected_labels
 
         self._dataloader = DataLoader(
             dataset,
@@ -458,7 +487,7 @@ class DirectPreferenceOptimizationDataLoader:
 
         def _calculate():
             return sum(self._dataloader.dataset.map(
-                lambda ex: {'len': len(ex['prompt_input_ids']) + len(ex['chosen_input_ids']) + len(ex['rejected_input_ids'])},
+                lambda ex: {'len': len(ex['chosen_input_ids']) + len(ex['rejected_input_ids'])},
                 num_proc=self.number_of_cpu_processes,
                 remove_columns=[],
                 desc='Calculating number of tokens'
@@ -577,8 +606,9 @@ def init_data_loaders(
                 split='train',
                 use_shuffle=True,
                 pad_id=pad_id,
-                drop_last=False,
-                number_of_cpu_processes=number_of_cpu_processes
+                drop_last=True,
+                number_of_cpu_processes=number_of_cpu_processes,
+                ignore_index=ignore_index
             )
         val_loader = DirectPreferenceOptimizationDataLoader(
             batch_size=batch_size,
@@ -591,7 +621,8 @@ def init_data_loaders(
             use_shuffle=False,
             pad_id=pad_id,
             drop_last=False,
-            number_of_cpu_processes=number_of_cpu_processes
+            number_of_cpu_processes=number_of_cpu_processes,
+            ignore_index=ignore_index
         )
     else:
         raise ValueError('Invalid training stage for dataloader')

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -64,6 +64,42 @@ def prepare_workload_summary(
 
     return summary
 
+def format_dpo_console_metrics(aggregated_metrics: dict[str, float]) -> str:
+    required = [
+        'Accuracy',
+        'Margin',
+        'Rewards/Chosen',
+        'Rewards/Rejected',
+    ]
+
+    if not all(key in aggregated_metrics for key in required):
+        return ''
+
+    acc = aggregated_metrics['Accuracy']
+    margin = aggregated_metrics['Margin']
+    reward_chosen = aggregated_metrics['Rewards/Chosen']
+    reward_rejected = aggregated_metrics['Rewards/Rejected']
+
+    message = (
+        f'\n       dpo acc: {acc:.4f} | '
+        f'margin: {margin:.4f} | '
+        f'r+/r-: {reward_chosen:.4f} / {reward_rejected:.4f}'
+    )
+
+    if (
+        'PolicyLogP/Chosen' in aggregated_metrics and
+        'PolicyLogP/Rejected' in aggregated_metrics
+    ):
+        policy_chosen = aggregated_metrics['PolicyLogP/Chosen']
+        policy_rejected = aggregated_metrics['PolicyLogP/Rejected']
+
+        message += (
+            f' | '
+            f'logp+/logp-: {policy_chosen:.2f} / {policy_rejected:.2f}'
+        )
+
+    return message
+
 def prepare_train_step_log(
     *,
     step_metrics: StepMetrics,
@@ -95,6 +131,8 @@ def prepare_train_step_log(
     peak_allocated_mb = memory_usage_metrics.peak_allocated_mb
     peak_reserved_mb = memory_usage_metrics.peak_reserved_mb
 
+    dpo_console_message = format_dpo_console_metrics(aggregated_metrics)
+
     console_log = (
         f'{step:4d} | '
         f'train loss: {train_loss:.4f} | '
@@ -105,6 +143,7 @@ def prepare_train_step_log(
         f'tok/s: {int(tokens_per_sec)}'
         f'\n       mem MiB current alloc/res: {current_allocated_mb:.0f} / {current_reserved_mb:.0f} | '
         f'peak alloc/res: {peak_allocated_mb:.0f} / {peak_reserved_mb:.0f}'
+        f'{dpo_console_message}'
     )
 
     wandb_metrics = dict(aggregated_metrics)
@@ -137,9 +176,12 @@ def prepare_val_step_log(
 
     step = trainer_state.current_step
 
+    dpo_console_message = format_dpo_console_metrics(aggregated_metrics)
+
     console_log = (
         f'{step:4d} | '
         f'val loss: {trainer_state.last_val_loss:.4f}'
+        f'{dpo_console_message}'
     )
 
     wandb_metrics = {'Validation Loss': trainer_state.last_val_loss}

--- a/inference/generation.py
+++ b/inference/generation.py
@@ -256,7 +256,7 @@ def generate_and_decode(
 
         if not skip_encoding:
             prompt_tokens = [
-                tokenizer.encode_instruct(prompt) if is_instruct else tokenizer.encode(prompt)
+                tokenizer.encode_instruct_inference(prompt) if is_instruct else tokenizer.encode(prompt)
                 for prompt in prompts
             ]
         else:

--- a/tasks/dpo.py
+++ b/tasks/dpo.py
@@ -49,23 +49,35 @@ class DPOTask(BaseTask):
         use_autocast = self.ctx.precision.use_autocast
         grad_accum_steps = self.ctx.grad_accum_steps
         dpo_beta = self.config.dpo.beta
+        ignore_index = self.config.tokenizer.ignore_index
 
-        # x, y, z = prompt, chosen, rejected
-        x, y, z = batch
-        x = x.to(device, non_blocking=True)
-        y = y.to(device, non_blocking=True)
-        z = z.to(device, non_blocking=True)
+        chosen_input_ids, chosen_labels, rejected_input_ids, rejected_labels = batch
+        chosen_input_ids = chosen_input_ids.to(device, non_blocking=True)
+        chosen_labels = chosen_labels.to(device, non_blocking=True)
+        rejected_input_ids = rejected_input_ids.to(device, non_blocking=True)
+        rejected_labels = rejected_labels.to(device, non_blocking=True)
 
-        tokens_processed = 4 * x.numel() + 2 * y.numel() + 2 * z.numel()
+        chosen_valid_tokens = (chosen_labels != ignore_index).sum()
+        rejected_valid_tokens = (rejected_labels != ignore_index).sum()
+
+        if chosen_valid_tokens.item() == 0:
+            raise ValueError('DPO batch has no supervised chosen tokens')
+        if rejected_valid_tokens.item() == 0:
+            raise ValueError('DPO batch has no supervised rejected tokens')
+
+        tokens_processed = (
+            chosen_input_ids.numel()
+            + rejected_input_ids.numel()
+        )
 
         with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
-            policy_log_probs_pos = dpo_log_probs(model, x, y)
-            policy_log_probs_neg = dpo_log_probs(model, x, z)
+            policy_log_probs_pos = dpo_log_probs(model, chosen_input_ids, chosen_labels, ignore_index)
+            policy_log_probs_neg = dpo_log_probs(model, rejected_input_ids, rejected_labels, ignore_index)
 
         with torch.no_grad():
             with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
-                reference_log_probs_pos = dpo_log_probs(assets.dpo_ref_model, x, y)
-                reference_log_probs_neg = dpo_log_probs(assets.dpo_ref_model, x, z)
+                reference_log_probs_pos = dpo_log_probs(assets.dpo_ref_model, chosen_input_ids, chosen_labels, ignore_index)
+                reference_log_probs_neg = dpo_log_probs(assets.dpo_ref_model, rejected_input_ids, rejected_labels, ignore_index)
 
         loss, dpo_metrics = dpo_loss(
             policy_log_probs_pos,
@@ -77,10 +89,11 @@ class DPOTask(BaseTask):
 
         loss_for_backward = loss / grad_accum_steps
 
-        n_valid = x.size(0) # Assume 1 valid example as the entire triple.
-
-        if not torch.is_tensor(n_valid):
-            n_valid = torch.tensor(n_valid, device=device, dtype=loss.dtype)
+        n_valid = torch.tensor(
+            chosen_input_ids.size(0),
+            device=device,
+            dtype=loss.dtype
+        )
 
         return TaskStepOutput(
             tokens_processed=tokens_processed,
@@ -101,18 +114,28 @@ class DPOTask(BaseTask):
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
         dpo_beta = self.config.dpo.beta
+        ignore_index = self.config.tokenizer.ignore_index
 
-        # x, y, z = prompt, chosen, rejected
-        x, y, z = batch
-        x = x.to(device, non_blocking=True)
-        y = y.to(device, non_blocking=True)
-        z = z.to(device, non_blocking=True)
+        chosen_input_ids, chosen_labels, rejected_input_ids, rejected_labels = batch
+
+        chosen_input_ids = chosen_input_ids.to(device, non_blocking=True)
+        chosen_labels = chosen_labels.to(device, non_blocking=True)
+        rejected_input_ids = rejected_input_ids.to(device, non_blocking=True)
+        rejected_labels = rejected_labels.to(device, non_blocking=True)
+
+        chosen_valid_tokens = (chosen_labels != ignore_index).sum()
+        rejected_valid_tokens = (rejected_labels != ignore_index).sum()
+
+        if chosen_valid_tokens.item() == 0:
+            raise ValueError('DPO validation batch has no supervised chosen tokens')
+        if rejected_valid_tokens.item() == 0:
+            raise ValueError('DPO validation batch has no supervised rejected tokens')
 
         with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
-            policy_log_probs_pos = dpo_log_probs(model, x, y)
-            policy_log_probs_neg = dpo_log_probs(model, x, z)
-            reference_log_probs_pos = dpo_log_probs(assets.dpo_ref_model, x, y)
-            reference_log_probs_neg = dpo_log_probs(assets.dpo_ref_model, x, z)
+            policy_log_probs_pos = dpo_log_probs(model, chosen_input_ids, chosen_labels, ignore_index)
+            policy_log_probs_neg = dpo_log_probs(model, rejected_input_ids, rejected_labels, ignore_index)
+            reference_log_probs_pos = dpo_log_probs(assets.dpo_ref_model, chosen_input_ids, chosen_labels, ignore_index)
+            reference_log_probs_neg = dpo_log_probs(assets.dpo_ref_model, rejected_input_ids, rejected_labels, ignore_index)
 
         loss, dpo_metrics = dpo_loss(
             policy_log_probs_pos,
@@ -121,7 +144,11 @@ class DPOTask(BaseTask):
             reference_log_probs_neg,
             dpo_beta
         )
-        n_valid = torch.tensor(x.size(0), device=device, dtype=loss.dtype) # Assume 1 valid example as the entire triple.
+        n_valid = torch.tensor(
+            chosen_input_ids.size(0),
+            device=device,
+            dtype=loss.dtype
+        )
 
         return TaskStepOutput(
             n_valid=n_valid,

--- a/tasks/dpo.py
+++ b/tasks/dpo.py
@@ -100,7 +100,6 @@ class DPOTask(BaseTask):
             n_valid=n_valid,
             loss=loss,
             loss_for_backward=loss_for_backward,
-            console_logs=[dpo_metrics['str']],
             metrics={
                 'Train Loss': loss.detach(),
                 **dpo_metrics['wandb']
@@ -153,6 +152,5 @@ class DPOTask(BaseTask):
         return TaskStepOutput(
             n_valid=n_valid,
             loss=loss,
-            console_logs=[dpo_metrics['str']],
             metrics=dpo_metrics['wandb']
         )

--- a/tasks/dpo_utils.py
+++ b/tasks/dpo_utils.py
@@ -52,13 +52,17 @@ def dpo_loss(
     margin_avg = margin.mean().item()
     pol_logprobs_pos = policy_log_probs_pos.mean().item()
     pol_logprobs_neg = policy_log_probs_neg.mean().item()
+    ref_logprobs_pos = reference_log_probs_pos.mean().item()
+    ref_logprobs_neg = reference_log_probs_neg.mean().item()
 
     metrics_s = (
         f'rewards/chosen: {rewards_chosen:4f} | '
         f'rewards/rejected: {rewards_rejected:4f} | '
         f'accuracy: {accuracy:4f} | margin: {margin_avg:4f} | '
         f'pol_logprobs/chosen: {pol_logprobs_pos:4f} | '
-        f'pol_logprobs/rejected: {pol_logprobs_neg:4f}'
+        f'pol_logprobs/rejected: {pol_logprobs_neg:4f} | '
+        f'ref_logprobs/chosen: {ref_logprobs_pos:4f} | '
+        f'ref_logprobs/rejected: {ref_logprobs_neg:4f}'
     )
     metrics = {
         'str': metrics_s,
@@ -68,7 +72,9 @@ def dpo_loss(
             'Accuracy': accuracy,
             'Margin': margin_avg,
             'PolicyLogP/Chosen': pol_logprobs_pos,
-            'PolicyLogP/Rejected': pol_logprobs_neg
+            'PolicyLogP/Rejected': pol_logprobs_neg,
+            'ReferenceLogP/Chosen': ref_logprobs_pos,
+            'ReferenceLogP/Rejected': ref_logprobs_neg
         }
     }
     return loss, metrics

--- a/tasks/dpo_utils.py
+++ b/tasks/dpo_utils.py
@@ -2,47 +2,30 @@ import torch
 import torch.nn.functional as F
 
 
-def dpo_log_probs(model, prompt_ids, resp_ids):
-    ''' Computes de log probabilities for each entry in the batch. Prompt + response.
+def dpo_log_probs(model, input_ids, labels, ignore_index):
+    ''' Computes de log probabilities for DPO.
 
-        Assumes dimensions prompt_ids [B, P] and resp_ids [B, R]
+        Assumes dimensions input_ids [B, L] and labels_ids [B, L]
+        labels here are already shifted. Prompt and pad tokens are ignore_index (ignored)
     '''
-    device = prompt_ids.device
-
-    # Get dimensions
-    B, P = prompt_ids.shape
-    R = resp_ids.size(1)
-
-    # Here we concatenate prompt + response but remove the last token (once it goes in the model, for each token we predict the next). Lets assume L = size prompt length + response length
-    full_input = torch.cat([prompt_ids, resp_ids[:, :-1]], dim=1) # [B, L]
-    # The response flattened
-    labels = resp_ids.reshape(-1) # [B * R]
-
     # compute logits
-    logits = model(full_input)['logits'] # [B, L, V]
+    logits = model(input_ids)['logits'] # [B, L, V]
+    log_probs = F.log_softmax(logits, dim=-1)
 
-    # Flatten B * L
-    logits_flat = F.log_softmax(logits, dim=-1).view(-1, logits.size(-1)) # [B * L, V]
+    mask = labels != ignore_index # [B, L]
+    safe_labels = labels.masked_fill(~mask, 0)
 
-    L = logits.size(1)
-    # Since we have a flat representation and we need to get the logprobs of the response segments, we do:
-    # - Generate the base indexes that will contain the response for the first item in the batch. Then repeat this B times E.g: Indexes [3, 4, 5] and B = 2 -> [[3, 4, 5], [3, 4, 5]]
-    base_indexes = torch.arange(P - 1, L, device=device).repeat(B)
-    # - Generate the offsets by taking advantage of batch size and creating B entries that jump L by L E.g: If L is 2 [[0],[2]]. Finally for each of them we allocate
-    # space for the response by repeating R times. E.g if R = 2 -> [[0, 0],[2, 2]]
-    offsets = (torch.arange(B, device=device) * L).repeat_interleave(R)
+    token_log_probs = log_probs.gather(
+        dim=-1,
+        index=safe_labels.unsqueeze(-1)
+    ).squeeze(-1) # [B, L]
 
-    # Add them together and we have a mask for all the resp positions accross all entries.
-    resp_pos = base_indexes + offsets
+    # cancels the fake log probs in token_log_probs
+    token_log_probs = token_log_probs * mask
 
-    # Get log probabilites of the response tokens (labels)
-    resp_logp = logits_flat[resp_pos, labels]
-
-    # Restore dimensions and sum accoss axis 1 to get the response log probs for each entry in the batch
-    logp_per_sequence = resp_logp.view(B, R).sum(dim=-1)
+    logp_per_sequence = token_log_probs.sum(dim=-1)  # [B]
 
     return logp_per_sequence
-
 
 def dpo_loss(
     policy_log_probs_pos,
@@ -70,7 +53,13 @@ def dpo_loss(
     pol_logprobs_pos = policy_log_probs_pos.mean().item()
     pol_logprobs_neg = policy_log_probs_neg.mean().item()
 
-    metrics_s = f'rewards/chosen: {rewards_chosen:4f} | rewards/rejected: {rewards_rejected:4f} | accuracy: {accuracy:4f} | margin: {margin_avg:4f} | pol_logprobs/chosen: {pol_logprobs_pos:4f} | pol_logprobs/rejected: {pol_logprobs_neg:4f}'
+    metrics_s = (
+        f'rewards/chosen: {rewards_chosen:4f} | '
+        f'rewards/rejected: {rewards_rejected:4f} | '
+        f'accuracy: {accuracy:4f} | margin: {margin_avg:4f} | '
+        f'pol_logprobs/chosen: {pol_logprobs_pos:4f} | '
+        f'pol_logprobs/rejected: {pol_logprobs_neg:4f}'
+    )
     metrics = {
         'str': metrics_s,
         'wandb': {

--- a/tokenization/base.py
+++ b/tokenization/base.py
@@ -1,6 +1,78 @@
 from abc import ABC, abstractmethod
 
 
+class PromptBuilder:
+    def __init__(self, tokenizer, *, ignore_index=None, no_labels=False):
+        self.tokenizer = tokenizer
+        if no_labels is False and ignore_index is None:
+            raise ValueError('ignore_index cannot be None when building labels')
+        self.ignore_index = ignore_index
+        self.no_labels = no_labels
+        self.system_prompt = tokenizer.system_prompt
+        self.bot = tokenizer.bos_id
+        self.sh = tokenizer.sh_id
+        self.eh = tokenizer.eh_id
+        self.eot = tokenizer.eot_id
+        self.eos = tokenizer.eos_id
+        self.tokens = []
+        self.labels = []
+
+    def encode(self, text):
+        return self.tokenizer.encode(text)
+
+    def push(self, tok_ids, supervise=False):
+        self.tokens.extend(tok_ids)
+        if self.no_labels:
+            return
+        if supervise:
+            self.labels.extend(tok_ids)
+        else:
+            self.labels.extend([self.ignore_index] * len(tok_ids))
+
+    def add_header(self, system_msg=True):
+        self.push([self.bot], supervise=False)
+        if system_msg:
+            self.add_role_prefix('system')
+            self.push(self.encode(self.system_prompt), supervise=False)
+            self.push([self.eot], supervise=False)
+
+    def add_role_prefix(self, role):
+        self.push([self.sh], supervise=False)
+        self.push(self.encode(role), supervise=False)
+        self.push([self.eh], supervise=False)
+        self.push(self.encode('\n'), supervise=False)
+
+    def add_message(self, role, text, *, supervise=False, final_assistant=False):
+        self.add_role_prefix(role)
+        self.push(self.encode(text), supervise=supervise)
+        if final_assistant:
+            self.push([self.eos], supervise=supervise)
+        else:
+            self.push([self.eot], supervise=supervise and role == 'assistant')
+
+    def clone(self):
+        other = PromptBuilder(
+            self.tokenizer,
+            ignore_index=self.ignore_index,
+            no_labels=self.no_labels
+        )
+        other.tokens = list(self.tokens)
+        other.labels = list(self.labels)
+        return other
+
+    def build(self):
+        if self.no_labels:
+            return self.tokens
+
+        if len(self.tokens) != len(self.labels):
+            raise ValueError(
+                f'Tokens and labels length do not match: {len(self.tokens)} vs {len(self.labels)}'
+            )
+
+        shifted_labels = self.labels[1:] + [self.ignore_index]
+
+        return self.tokens, shifted_labels
+
 class BaseTokenizer(ABC):
 
     @abstractmethod
@@ -11,119 +83,76 @@ class BaseTokenizer(ABC):
     def decode(self, ids):
         ...
 
-    def encode_instruct(self, s, system_msg=True):
-        bot = self.bos_id
-        sh = self.sh_id
-        eh = self.eh_id
-        eot = self.eot_id
+    def encode_instruct_inference(
+        self,
+        text: str,
+        system_msg: bool = True
+    ):
+        builder = PromptBuilder(self, no_labels=True)
+        builder.add_header(system_msg=system_msg)
+        builder.add_message('user', text, supervise=False)
+        builder.add_role_prefix('assistant')
+        return builder.build()
 
-        tokens = [bot, sh]
-        if system_msg:
-            tokens.extend(self.encode('system'))
-            tokens.extend([eh])
-            tokens.extend(self.encode('\n' + self.system_prompt))
-            tokens.extend([eot, sh])
-        tokens.extend(self.encode('user'))
-        tokens.extend([eh])
-        tokens.extend(self.encode('\n'))
-        tokens.extend(self.encode(s))
-        tokens.extend([eot, sh])
-        tokens.extend(self.encode('assistant'))
-        tokens.extend([eh])
-        tokens.extend(self.encode('\n'))
-        return tokens
-
-    def encode_chat(
+    def encode_instruct_chat(
         self,
         *,
         conversation: object,
         ignore_index: int
     ):
-        bot = self.bos_id
-        sh = self.sh_id
-        eh = self.eh_id
-        eot = self.eot_id
-        eos = self.eos_id
-
-        tokens, labels = [], []
-        def push(tok_ids, is_assistant):
-            tokens.extend(tok_ids)
-            if is_assistant:
-                labels.extend(tok_ids)
-            else:
-                labels.extend([ignore_index] * len(tok_ids))
-
-        push([bot], False)
-        push([sh], False)
-        push(self.encode('system'), False)
-        push([eh], False)
-        push(self.encode('\n' + self.system_prompt), False)
-        push([eot], False)
+        builder = PromptBuilder(self, ignore_index=ignore_index)
+        builder.add_header(system_msg=True)
 
         for idx, interaction in enumerate(conversation):
             role = interaction['role']
             content = interaction['content']
 
-            is_assistant = role == 'assistant'
-            is_last_message = idx == len(conversation) - 1
+            is_assistant = (role == 'assistant')
+            is_last_message = (idx == len(conversation) - 1)
 
-            push([sh], False)
-            push(self.encode(role), False)
-            push([eh], False)
-            push(self.encode('\n'), False)
-            push(self.encode(content), is_assistant)
+            builder.add_message(
+                role,
+                content,
+                supervise=is_assistant,
+                final_assistant=(is_assistant and is_last_message)
+            )
 
-            if is_last_message and is_assistant:
-                push([eos], True)
-            else:
-                push([eot], is_assistant)
+        return builder.build()
 
-        labels = labels[1:] + [ignore_index]
-
-        return tokens, labels
-
-    def encode_chat_dpo(
+    def encode_instruct_chat_dpo(
         self,
         *,
         conversation: object,
         chosen: str,
         rejected: str,
+        ignore_index: int
     ):
-        bot = self.bos_id
-        sh = self.sh_id
-        eh = self.eh_id
-        eot = self.eot_id
-
-        tokens = []
-        tokens.extend([bot])
-        tokens.extend([sh])
-        tokens.extend(self.encode('system'))
-        tokens.extend([eh])
-        tokens.extend(self.encode('\n' + self.system_prompt))
-        tokens.extend([eot])
+        prefix = PromptBuilder(self, ignore_index=ignore_index)
+        prefix.add_header(system_msg=True)
 
         for interaction in conversation:
             role = interaction['role']
             content = interaction['content']
 
-            tokens.extend([sh])
-            tokens.extend(self.encode(role))
-            tokens.extend([eh])
-            tokens.extend(self.encode('\n'))
-            tokens.extend(self.encode(content))
-            tokens.extend([eot])
+            prefix.add_message(
+                role,
+                content,
+                supervise=False,
+                final_assistant=False
+            )
 
-        def build_answer_sequence(text):
-            tokens = []
-            tokens.extend([sh])
-            tokens.extend(self.encode('assistant'))
-            tokens.extend([eh])
-            tokens.extend(self.encode('\n'))
-            tokens.extend(self.encode(text))
-            tokens.extend([eot])
-            return tokens
+        prefix.add_role_prefix('assistant')
 
-        chosen_tokens = build_answer_sequence(chosen)
-        rejected_tokens = build_answer_sequence(rejected)
+        def build_answer(answer):
+            builder = prefix.clone()
 
-        return tokens, chosen_tokens, rejected_tokens
+            builder.push(builder.encode(answer), supervise=True)
+            builder.push([builder.eos], supervise=True)
+
+            return builder.build()
+
+        prompt_input_ids, _ = prefix.build()
+        chosen_input_ids, chosen_labels = build_answer(chosen)
+        rejected_input_ids, rejected_labels = build_answer(rejected)
+
+        return prompt_input_ids, chosen_input_ids, chosen_labels, rejected_input_ids, rejected_labels


### PR DESCRIPTION
Main changes:
- `tokenizer.base` Now handles all the structured encoding and is used by `prepare_datasets` scripts;
- DPO:
  - labels are now computed following the same logic added for SFT. (During encoding we create the labels);
  - dataloader uses the same padding, truncating logics as SFT;
  - Fixed the missing `eos` token in the prompt structure;
  - Added more checks in the collate functions to prevent weird issues;
  - Simplified how DPO log probs are calculated now that the labels are already available;
  - Improved train / val step logging for DPO (it was spamming before) and added 2 useful metrics (Reference model log probs (chosen / rejected));
- Default config HF_HOME path should use the project dir;