### PR TITLE
Full refactor of the tokenize and shard approach for pretraining

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,6 @@ class ThirdPartyConfig(BaseSettings):
 
 class DatasetPreparationConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    hf_include_source_id: bool = False
     mp_pool_chunk_size: int = 64
     hf_map_batch_size: int = 1000
     hf_map_writer_batch_size: int = 1000

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -10,6 +10,11 @@ from tqdm.auto import tqdm
 from functools import partial
 from pathlib import Path
 from logger import logger
+from utils import (
+    load_json_file,
+    save_json_file
+)
+from dataclasses import dataclass
 
 
 def get_max_number_of_cpu_processes(config):
@@ -116,6 +121,39 @@ class ShardWriter:
         self.total_tokens = 0
         self.buffer = np.empty((self.shard_size,), dtype=np.uint32)
         self.progress_bar = None
+
+    def get_state_dict(self):
+        return {
+            'shard_index': self.shard_index,
+            'token_count': self.token_count,
+            'total_tokens': self.total_tokens
+        }
+
+    def load_state_dict(self, state):
+        self.shard_index = state['shard_index']
+        self.token_count = state['token_count']
+        self.total_tokens = state['total_tokens']
+
+    def get_buffer_checkpoint(self):
+        return self.buffer[:self.token_count]
+
+    def load_buffer_checkpoint(self, buffer):
+        assert buffer.size == self.token_count, (
+            f'{self.split_name} buffer size does no match: '
+            f'buffer has {buffer.size} but state expects {self.token_count}'
+        )
+        self.buffer[:self.token_count] = buffer.astype(np.uint32, copy=False)
+
+    def delete_shards_from_current_index(self):
+        for path in self.cache_dir.glob(f'{self.shard_file_prefix}_*.npy'):
+            try:
+                shard_index = int(path.stem.rsplit('_', 1)[1])
+            except (IndexError, ValueError):
+                continue
+
+            if shard_index >= self.shard_index:
+                logger.warning(f'Removing stale shard created after resume checkpoint: {path}')
+                path.unlink()
 
     def is_done(self):
         return self.target_tokens is not None and self.total_tokens >= self.target_tokens
@@ -242,6 +280,90 @@ def shard_and_tokenize(
     num_proc,
     chunksize
 ):
+    root_path = Path(train_path).parent
+    state_dir = root_path / '.prep_state'
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    state_path = state_dir / 'state.json'
+    train_buffer_path = state_dir / 'train_buffer.npy'
+    val_buffer_path = state_dir / 'val_buffer.npy'
+
+    @dataclass
+    class ShardAndTokenizeState:
+        train_writer: ShardWriter
+        val_writer: ShardWriter
+        status: str
+        docs_seen: int
+        source_doc_counts: dict
+        source_token_counts: dict
+        split_doc_counts: dict
+        split_token_counts: dict
+
+    def save_state(state: ShardAndTokenizeState):
+        state_data = {
+            'status': state.status,
+            'docs_seen': state.docs_seen,
+            'source_doc_counts': state.source_doc_counts,
+            'source_token_counts': state.source_token_counts,
+            'split_doc_counts': state.split_doc_counts,
+            'split_token_counts': state.split_token_counts,
+            'train_writer_state': state.train_writer.get_state_dict(),
+            'train_writer_buffer_file_path': str(train_buffer_path),
+            'val_writer_state': state.val_writer.get_state_dict(),
+            'val_writer_buffer_file_path': str(val_buffer_path),
+        }
+
+        temp_state_path = state_path.with_name(f'{state_path.name}.tmp')
+        temp_train_buffer_path = train_buffer_path.with_name(f'{train_buffer_path.stem}.tmp.npy')
+        temp_val_buffer_path = val_buffer_path.with_name(f'{val_buffer_path.stem}.tmp.npy')
+
+        try:
+            np.save(temp_train_buffer_path, state.train_writer.get_buffer_checkpoint())
+            np.save(temp_val_buffer_path, state.val_writer.get_buffer_checkpoint())
+            save_json_file(temp_state_path, state_data)
+
+            temp_train_buffer_path.replace(train_buffer_path)
+            temp_val_buffer_path.replace(val_buffer_path)
+            temp_state_path.replace(state_path)
+        except Exception as e:
+            logger.error(f'\nError saving state: {e}')
+            logger.error('Stopping processing. Need to rerun the script to resume...')
+
+            for path in [temp_state_path, temp_train_buffer_path, temp_val_buffer_path]:
+                try:
+                    if path.exists():
+                        path.unlink()
+                except OSError:
+                    pass
+
+            sys.exit(1)
+
+    def load_state(state: ShardAndTokenizeState):
+        if not (
+            state_path.exists() and
+            train_buffer_path.exists() and
+            val_buffer_path.exists()
+        ):
+            return state, False
+
+        logger.info(f'Loading state from: {state_dir}')
+        state_data = load_json_file(state_path)
+        train_buffer = np.load(train_buffer_path)
+        val_buffer = np.load(val_buffer_path)
+
+        state.status = state_data['status']
+        state.docs_seen = state_data['docs_seen']
+        state.source_doc_counts = state_data['source_doc_counts']
+        state.source_token_counts = state_data['source_token_counts']
+        state.split_doc_counts = state_data['split_doc_counts']
+        state.split_token_counts = state_data['split_token_counts']
+        state.train_writer.load_state_dict(state_data['train_writer_state'])
+        state.train_writer.load_buffer_checkpoint(train_buffer)
+        state.val_writer.load_state_dict(state_data['val_writer_state'])
+        state.val_writer.load_buffer_checkpoint(val_buffer)
+
+        return state, True
+
     shard_size = int(shard_size)
     assert shard_size > 0
 
@@ -252,12 +374,11 @@ def shard_and_tokenize(
     validation_ratio = float(validation_ratio)
     assert 0.0 <= validation_ratio < 1.0
 
+    val_target_tokens = 0
     if target_tokens is not None and validation_ratio > 0.0:
         val_target_tokens = math.ceil(
             target_tokens * validation_ratio / (1.0 - validation_ratio)
         )
-    else:
-        val_target_tokens = 0
 
     train_writer = ShardWriter(
         target_folder=train_path,
@@ -280,16 +401,37 @@ def shard_and_tokenize(
             return False
         return train_writer.is_done() and val_writer.is_done()
 
-    source_doc_counts = {}
-    source_token_counts = {}
-    split_doc_counts = {
-        'train': 0,
-        'val': 0,
-    }
-    split_token_counts = {
-        'train': 0,
-        'val': 0,
-    }
+    checkpoint_interval_docs = max(1, num_proc * chunksize) # save every time all workers complete.
+
+    state = ShardAndTokenizeState(
+        train_writer=train_writer,
+        val_writer=val_writer,
+        status='preparing',
+        docs_seen=0,
+        source_doc_counts={},
+        source_token_counts={},
+        split_doc_counts={ 'train': 0, 'val': 0 },
+        split_token_counts={ 'train': 0, 'val': 0 }
+    )
+    state, loaded = load_state(state)
+    if state.status == 'completed':
+        logger.info(f'Pretraining data preparation already completed: {state_dir}')
+        return
+
+    if not loaded:
+        for folder in [Path(train_path), Path(val_path)]:
+            existing = sorted(folder.glob(f'{shard_file_prefix}_*.npy'))
+            assert not existing, (
+                f'Output folder already contains shards but no resume state exists: {folder}'
+            )
+
+    if state.docs_seen > 0:
+        logger.info(f'Resuming from doc offset: {state.docs_seen:,}')
+        dataset = dataset.skip(state.docs_seen)
+
+        # delete stale shards...
+        train_writer.delete_shards_from_current_index()
+        val_writer.delete_shards_from_current_index()
 
     logger.info('Preparing pretraining train and val shards...')
 
@@ -306,6 +448,8 @@ def shard_and_tokenize(
             chunksize=chunksize
         )
         for source, tokens, split in iterator:
+            state.docs_seen += 1
+
             if tokens.size == 0:
                 continue
             if split == 'val':
@@ -318,10 +462,13 @@ def shard_and_tokenize(
                     break
                 continue
 
-            source_doc_counts[source] = source_doc_counts.get(source, 0) + 1
-            source_token_counts[source] = source_token_counts.get(source, 0) + written
-            split_doc_counts[split] += 1
-            split_token_counts[split] += written
+            state.source_doc_counts[source] = state.source_doc_counts.get(source, 0) + 1
+            state.source_token_counts[source] = state.source_token_counts.get(source, 0) + written
+            state.split_doc_counts[split] += 1
+            state.split_token_counts[split] += written
+
+            if state.docs_seen % checkpoint_interval_docs == 0:
+                save_state(state)
 
             if reached_target():
                 logger.info(f'Reached target train tokens: {train_writer.total_tokens:,}')
@@ -331,6 +478,9 @@ def shard_and_tokenize(
     train_writer.finish()
     val_writer.finish()
 
+    state.status = 'completed'
+    save_state(state)
+
     # Workaround for occasional pool shutdown issue...
     # Without this, some streaming runs crash after successful shard writing with PyGILState_Release during finalization...
     logger.info('Ensuring pool is terminated...')
@@ -339,13 +489,13 @@ def shard_and_tokenize(
     logger.info('Pretraining shard preparation complete.')
     logger.info(f'- Train tokens: {train_writer.total_tokens:,}')
     logger.info(f'- Val tokens: {val_writer.total_tokens:,}')
-    logger.info(f'- Train docs: {split_doc_counts["train"]:,}')
-    logger.info(f'- Val docs: {split_doc_counts["val"]:,}')
+    logger.info(f'- Train docs: {state.split_doc_counts["train"]:,}')
+    logger.info(f'- Val docs: {state.split_doc_counts["val"]:,}')
 
     logger.info('Source document counts:')
-    for source, count in sorted(source_doc_counts.items()):
+    for source, count in sorted(state.source_doc_counts.items()):
         logger.info(f'- {source}: {count:,}')
 
     logger.info('Source token counts:')
-    for source, count in sorted(source_token_counts.items()):
+    for source, count in sorted(state.source_token_counts.items()):
         logger.info(f'- {source}: {count:,}')

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -374,11 +374,14 @@ def shard_and_tokenize(
     validation_ratio = float(validation_ratio)
     assert 0.0 <= validation_ratio < 1.0
 
-    val_target_tokens = 0
-    if target_tokens is not None and validation_ratio > 0.0:
-        val_target_tokens = math.ceil(
-            target_tokens * validation_ratio / (1.0 - validation_ratio)
-        )
+    val_target_tokens = None
+    if target_tokens is not None:
+        if validation_ratio > 0.0:
+            val_target_tokens = math.ceil(
+                target_tokens * validation_ratio / (1.0 - validation_ratio)
+            )
+        else:
+            val_target_tokens = 0
 
     train_writer = ShardWriter(
         target_folder=train_path,

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -1,23 +1,16 @@
 import os
-import glob
-import re
 import numpy as np
 import sys
 import multiprocessing as mp
 import hashlib
+import time
 import math
 
 from tqdm.auto import tqdm
 from functools import partial
+from pathlib import Path
 from logger import logger
 
-
-def stable_hash(text, *, seed=None, hash_bytes=8):
-    # fast and stable hash. More info: https://docs.python.org/3/library/hashlib.html#blake2
-    if seed is not None:
-        salt = f'{seed}-salt'.encode('utf-8')
-        return int.from_bytes(hashlib.blake2b(text.encode(), digest_size=8, key=salt).digest(), 'big')
-    return int.from_bytes(hashlib.blake2b(text.encode(), digest_size=8).digest(), 'big')
 
 def get_max_number_of_cpu_processes(config):
     num_processes = max(1, os.cpu_count() // 2)
@@ -26,15 +19,42 @@ def get_max_number_of_cpu_processes(config):
     logger.info(f'Number of CPU processes: {num_processes}\n')
     return num_processes
 
+def stable_hash(text, *, seed=None, hash_bytes=8):
+    # fast and stable hash. More info: https://docs.python.org/3/library/hashlib.html#blake2
+    if seed is not None:
+        salt = f'{seed}-salt'.encode('utf-8')
+        return int.from_bytes(hashlib.blake2b(text.encode(), digest_size=hash_bytes, key=salt).digest(), 'big')
+    return int.from_bytes(hashlib.blake2b(text.encode(), digest_size=hash_bytes).digest(), 'big')
+
+def make_source_key(ds_id, name):
+    if name and name != 'default':
+        return f'{ds_id}::{name}'
+    return ds_id
+
 def assert_common_structure_and_extract(datasets_mix, supported_datasets):
-    ''' Validates common file structure and extracts seed, valid datasets and probabilities (normalized weight distribution)
+    ''' Validates common file structure and extracts seed, common dataset settings, valid datasets and probabilities (normalized weight distribution)
     '''
-    assert 'datasets' in datasets_mix
     assert 'seed' in datasets_mix
-
-    datasets, seed = datasets_mix['datasets'], datasets_mix['seed']
-
+    seed = datasets_mix['seed']
     assert isinstance(seed, int)
+
+    # Validate common settings if present.
+    common_settings = datasets_mix.get('datasets_common_settings', {})
+    shard_size = None
+    target_tokens = None
+    validation_ratio = None
+    if 'shard_size' in common_settings:
+        shard_size = common_settings['shard_size']
+        assert shard_size is None or int(shard_size) > 0, 'datasets_common_settings.shard_size must be > 0'
+    if 'target_tokens' in common_settings:
+        target_tokens = common_settings['target_tokens']
+        assert target_tokens is None or isinstance(target_tokens, int), 'datasets_common_settings.target_tokens must be an integer'
+    if 'validation_ratio' in common_settings:
+        validation_ratio = common_settings['validation_ratio']
+        assert validation_ratio is None or isinstance(validation_ratio, float), 'datasets_common_settings.validation_ratio must be a float'
+
+    assert 'datasets' in datasets_mix
+    datasets = datasets_mix['datasets']
 
     # Validate candidates
     valid_datasets = []
@@ -44,8 +64,8 @@ def assert_common_structure_and_extract(datasets_mix, supported_datasets):
         for name in names:
             assert name in supported_datasets[dataset_id]
             assert 'weight' in datasets[dataset_id][name]
-            assert 0.0 <= float(datasets[dataset_id][name]['weight']) <= 1.0, 'weight must be a value between 0 and 1.'
             weight = float(datasets[dataset_id][name].get('weight', 0.0))
+            assert weight >= 0.0, f'weight must be >= 0 for {dataset_id}/{name}'
             if weight > 0:
                 valid_datasets.append({
                     'id': dataset_id,
@@ -60,159 +80,272 @@ def assert_common_structure_and_extract(datasets_mix, supported_datasets):
 
     # normalize probabilities
     total_p = sum(probabilities)
-    assert math.isclose(total_p, 1.0, rel_tol=1e-9, abs_tol=1e-12), f'weight distribution must add to 1. Currently: {total_p}'
+    assert total_p > 0.0, 'weight distribution must have positive total weight'
     probabilities = [p / total_p for p in probabilities]
 
-    def ds_with_name(ds):
-        _id, name = ds['id'], ds.get('name', None)
-        if name and name != 'default':
-            return f'{_id}_{name}'
-        return _id
+    mixture_probs = [
+        {make_source_key(ds['id'], ds.get('name', None)): round(p, 3)}
+        for ds, p in zip(valid_datasets, probabilities)
+    ]
+    logger.info(f'Mixture probabilities: {mixture_probs}\n')
 
-    logger.info(f'Mixture probabilities: {[{ds_with_name(ds): round(p, 3)} for ds, p in zip(valid_datasets, probabilities)]}\n')
-
-    return seed, valid_datasets, probabilities
+    return seed, common_settings, valid_datasets, probabilities
 
 def get_progress_bar(shard_index, shard_size, initial_tokens=0):
     return tqdm(total=shard_size, initial=initial_tokens, unit='tokens', desc=f'Shard {shard_index}')
 
-def get_filename(shard_index, data_cache_dir, shard_file_prefix):
-    base_filename = f'{shard_file_prefix}_{shard_index:06d}'
-    final_path = os.path.join(data_cache_dir, f'{base_filename}.npy')
-    temp_path = os.path.join(data_cache_dir, f'{base_filename}.temp.npy')
-    return temp_path, final_path
+class ShardWriter:
+    def __init__(self,
+        *,
+        target_folder,
+        shard_file_prefix,
+        shard_size,
+        split_name,
+        target_tokens=None
+    ):
+        self.cache_dir = Path(target_folder)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-def save_filename(all_tokens_np, shard_index, data_cache_dir, shard_file_prefix):
-    temp_filepath, final_filepath = get_filename(shard_index, data_cache_dir, shard_file_prefix)
-    try:
-        np.save(temp_filepath, all_tokens_np)
-        os.replace(temp_filepath, final_filepath) # Small protection in case of file corruption..
-    except Exception as e:
-        logger.error(f'\nError saving shard {shard_index} to {final_filepath}: {e}')
-        logger.error('Stopping processing. Rerun the script to resume.')
-        if os.path.exists(temp_filepath):
-            try: os.remove(temp_filepath)
-            except OSError: pass
-        sys.exit(1)
+        self.shard_file_prefix = shard_file_prefix
+        self.shard_size = int(shard_size)
+        self.split_name = split_name
+        self.target_tokens = target_tokens
 
+        self.shard_index = 0
+        self.token_count = 0
+        self.total_tokens = 0
+        self.buffer = np.empty((self.shard_size,), dtype=np.uint32)
+        self.progress_bar = None
 
-def find_last_shard_info(data_cache_dir, shard_file_prefix):
-    shard_pattern = re.compile(rf'^{re.escape(shard_file_prefix)}_(\d+)\.npy$')
-    files = []
+    def is_done(self):
+        return self.target_tokens is not None and self.total_tokens >= self.target_tokens
 
-    for file_path in glob.glob(os.path.join(data_cache_dir, f'{shard_file_prefix}_*.npy')):
-        match = shard_pattern.match(os.path.basename(file_path))
-        if match:
-            files.append((int(match.group(1)), file_path))
+    def init_progress_bar(self):
+        if self.progress_bar is None:
+            self.progress_bar = get_progress_bar(
+                shard_index=self.shard_index,
+                shard_size=self.shard_size,
+                initial_tokens=self.token_count
+            )
+            self.progress_bar.set_description(f'{self.split_name} shard {self.shard_index}')
 
-    if not files:
-        logger.info('No previous shards found.')
-        return -1, 0
+    def get_save_paths(self):
+        current_filename = f'{self.shard_file_prefix}_{self.shard_index:06d}'
+        final_path = self.cache_dir / f'{current_filename}.npy'
+        temp_path = self.cache_dir / f'{current_filename}.tmp.npy'
+        return final_path, temp_path
 
-    files.sort(key=lambda x: x[0])
+    def save_tokens(self, tokens):
+        final_path, temp_path = self.get_save_paths()
+        try:
+            np.save(temp_path, tokens.astype(np.uint32, copy=False))
+            temp_path.replace(final_path)
+        except Exception as e:
+            logger.error(f'\nError saving shard {self.shard_index} to {final_path}: {e}')
+            logger.error('Stopping processing. Need to rerun the script to resume...')
 
-    # validate sequence: There should not be missing shards like 1 2 3 6
-    indexes = [i for i, _ in files]
-    if indexes != list(range(0, indexes[-1] + 1)):
-        raise ValueError(f'Shard sequence broken: {indexes}')
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
 
-    total_tokens_saved = 0
-    for _, file_path in files:
-        shard = np.load(file_path, mmap_mode='r', allow_pickle=False)
-        total_tokens_saved += shard.shape[0]
-        del shard
+            sys.exit(1)
 
-    last_shard_index = files[-1][0]
-    logger.info(f'Resuming after shard {last_shard_index}. Total tokens in existing shards: {total_tokens_saved}')
-    return last_shard_index, total_tokens_saved
+    def save_shard(self):
+        if self.token_count == 0:
+            return
+        tokens = self.buffer if self.token_count == self.shard_size else self.buffer[:self.token_count]
+        self.save_tokens(tokens)
+        self.shard_index += 1
+        self.token_count = 0
 
-def prepare_dataset(
+    def finish(self):
+        if self.progress_bar is not None:
+            self.progress_bar.close()
+            self.progress_bar = None
+        self.save_shard()
+
+    def write(self, tokens):
+        if tokens.size == 0 or self.is_done():
+            return 0
+
+        tokens = tokens.astype(np.uint32, copy=False)
+
+        if self.target_tokens is not None:
+            remaining_target_tokens = self.target_tokens - self.total_tokens
+            tokens = tokens[:remaining_target_tokens]
+
+        written_count = 0
+        offset = 0
+
+        while offset < tokens.size:
+            self.init_progress_bar()
+
+            remaining_space = self.shard_size - self.token_count
+            slice_length = min(remaining_space, tokens.size - offset)
+
+            # populate the buffer
+            self.buffer[self.token_count : self.token_count + slice_length] = tokens[offset : offset + slice_length]
+
+            self.token_count += slice_length
+            self.total_tokens += slice_length
+
+            written_count += slice_length
+            offset += slice_length
+
+            self.progress_bar.update(slice_length)
+
+            if self.token_count == self.shard_size:
+                self.progress_bar.close()
+                self.progress_bar = None
+                self.save_shard()
+
+            if self.is_done():
+                break
+
+        return written_count
+
+def tokenize_and_route(
+    tokenizer_kwargs,
+    tokenize_function,
+    seed,
+    validation_ratio,
+    doc,
+):
+    source = doc.get('source', 'unknown')
+    tokens = tokenize_function(tokenizer_kwargs, doc)
+
+    # Makes assignment of 'train' or 'val' to the doc deterministic.
+    HASH_BYTES = 8
+    HASH_SPACE = 1 << (HASH_BYTES * 8) # 64 bit
+    SEPARATION_THRESHOLD = int(validation_ratio * HASH_SPACE)
+
+    is_val = stable_hash(doc['text'], seed=seed, hash_bytes=HASH_BYTES) < SEPARATION_THRESHOLD
+
+    split = 'val' if is_val else 'train'
+
+    return source, tokens, split
+
+def shard_and_tokenize(
     *,
+    seed,
     dataset,
     tokenize_function,
     tokenizer_kwargs,
-    target_folder,
+    train_path,
+    val_path,
     shard_file_prefix,
     shard_size,
+    target_tokens,
+    validation_ratio,
     num_proc,
     chunksize
 ):
-    data_cache_dir = os.path.join(os.getcwd(), target_folder)
-    os.makedirs(data_cache_dir, exist_ok=True)
+    shard_size = int(shard_size)
+    assert shard_size > 0
 
-    last_shard_index, tokens_to_skip = find_last_shard_info(data_cache_dir, shard_file_prefix)
-    start_shard_index = last_shard_index + 1
-    processed_token_count_in_loop = 0
-    skipping_phase = tokens_to_skip > 0
+    if target_tokens is not None:
+        target_tokens = int(target_tokens)
+        assert target_tokens > 0
 
-    skipping_progress_bar = None
-    if skipping_phase:
-        logger.info('Starting skipping phase...')
-        skipping_progress_bar = tqdm(total=tokens_to_skip, desc='Skipping tokens', unit='tokens', smoothing=0.1)
+    validation_ratio = float(validation_ratio)
+    assert 0.0 <= validation_ratio < 1.0
+
+    if target_tokens is not None and validation_ratio > 0.0:
+        val_target_tokens = math.ceil(
+            target_tokens * validation_ratio / (1.0 - validation_ratio)
+        )
+    else:
+        val_target_tokens = 0
+
+    train_writer = ShardWriter(
+        target_folder=train_path,
+        shard_file_prefix=shard_file_prefix,
+        shard_size=shard_size,
+        target_tokens=target_tokens,
+        split_name='train'
+    )
+
+    val_writer = ShardWriter(
+        target_folder=val_path,
+        shard_file_prefix=shard_file_prefix,
+        shard_size=shard_size,
+        target_tokens=val_target_tokens,
+        split_name='val'
+    )
+
+    def reached_target():
+        if target_tokens is None:
+            return False
+        return train_writer.is_done() and val_writer.is_done()
+
+    source_doc_counts = {}
+    source_token_counts = {}
+    split_doc_counts = {
+        'train': 0,
+        'val': 0,
+    }
+    split_token_counts = {
+        'train': 0,
+        'val': 0,
+    }
+
+    logger.info('Preparing pretraining train and val shards...')
 
     with mp.Pool(num_proc) as pool:
-        shard_index = start_shard_index
-        token_count = 0
-        progress_bar = None
-        all_tokens_np = np.empty((shard_size,), dtype=np.uint32)
-
-        for tokens in pool.imap(partial(tokenize_function, tokenizer_kwargs), dataset, chunksize=chunksize):
+        iterator = pool.imap(
+            partial(
+                tokenize_and_route,
+                tokenizer_kwargs,
+                tokenize_function,
+                seed,
+                validation_ratio
+            ),
+            dataset,
+            chunksize=chunksize
+        )
+        for source, tokens, split in iterator:
             if tokens.size == 0:
                 continue
-
-            tokens_len = tokens.size
-
-            # Skipping phase...
-            if skipping_phase:
-                if processed_token_count_in_loop + tokens_len <= tokens_to_skip:
-                    processed_token_count_in_loop += tokens_len
-                    if skipping_progress_bar:
-                        skipping_progress_bar.update(tokens_len)
-                    continue
-                else:
-                    if skipping_progress_bar:
-                        remaining_to_skip = tokens_to_skip - processed_token_count_in_loop
-                        if remaining_to_skip > 0:
-                            skipping_progress_bar.update(remaining_to_skip)
-                        skipping_progress_bar.close()
-                        skipping_progress_bar = None
-
-                    offset = tokens_to_skip - processed_token_count_in_loop
-                    tokens_to_process = tokens[offset:]
-                    tokens_len = tokens_to_process.size
-                    logger.info(f'Skipping phase complete. Starting to process from token {offset+1} of the current batch.')
-                    skipping_phase = False
+            if split == 'val':
+                written = val_writer.write(tokens)
             else:
-                tokens_to_process = tokens
+                written = train_writer.write(tokens)
 
-            if progress_bar is None:
-                progress_bar = get_progress_bar(shard_index, shard_size, initial_tokens=token_count)
+            if written == 0:
+                if reached_target():
+                    break
+                continue
 
-            # Normal processing...
-            if token_count + tokens_len < shard_size:
-                all_tokens_np[token_count:token_count + tokens_len] = tokens_to_process
-                token_count += tokens_len
-                progress_bar.update(tokens_len)
-            else:
-                remaining_space = shard_size - token_count
-                all_tokens_np[token_count:token_count + remaining_space] = tokens_to_process[:remaining_space]
-                progress_bar.update(remaining_space)
-                progress_bar.close()
+            source_doc_counts[source] = source_doc_counts.get(source, 0) + 1
+            source_token_counts[source] = source_token_counts.get(source, 0) + written
+            split_doc_counts[split] += 1
+            split_token_counts[split] += written
 
-                # save file
-                save_filename(all_tokens_np, shard_index, data_cache_dir, shard_file_prefix)
+            if reached_target():
+                logger.info(f'Reached target train tokens: {train_writer.total_tokens:,}')
+                logger.info(f'Reached target val tokens: {val_writer.total_tokens:,}')
+                break
 
-                shard_index += 1
-                progress_bar = None
+    train_writer.finish()
+    val_writer.finish()
 
-                tokens_leftover = tokens_to_process[remaining_space:]
-                token_count = tokens_leftover.size
-                all_tokens_np[:token_count] = tokens_leftover
+    # Workaround for occasional pool shutdown issue...
+    # Without this, some streaming runs crash after successful shard writing with PyGILState_Release during finalization...
+    logger.info('Ensuring pool is terminated...')
+    time.sleep(5)
 
-                if token_count > 0:
-                    progress_bar = get_progress_bar(shard_index, shard_size, initial_tokens=token_count)
+    logger.info('Pretraining shard preparation complete.')
+    logger.info(f'- Train tokens: {train_writer.total_tokens:,}')
+    logger.info(f'- Val tokens: {val_writer.total_tokens:,}')
+    logger.info(f'- Train docs: {split_doc_counts["train"]:,}')
+    logger.info(f'- Val docs: {split_doc_counts["val"]:,}')
 
-        if token_count > 0:
-            if progress_bar:
-                progress_bar.close()
-            save_filename(all_tokens_np[:token_count], shard_index, data_cache_dir, shard_file_prefix)
+    logger.info('Source document counts:')
+    for source, count in sorted(source_doc_counts.items()):
+        logger.info(f'- {source}: {count:,}')
+
+    logger.info('Source token counts:')
+    for source, count in sorted(source_token_counts.items()):
+        logger.info(f'- {source}: {count:,}')

--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -10,7 +10,10 @@ from datasets import (
     load_dataset,
     interleave_datasets
 )
-from datasets_preparation.data_preparation_utils import assert_common_structure_and_extract
+from datasets_preparation.data_preparation_utils import (
+    assert_common_structure_and_extract,
+    make_source_key
+)
 from datasets_preparation.default_mixes import DEFAULT_DPO_MIX
 from logger import logger
 
@@ -125,6 +128,7 @@ def download_and_prepare_data(
         max_datapoints = transforms.get('max_datapoints', None)
 
         hf_name = None if name == 'default' else name
+        source_key = make_source_key(ds_id, name)
 
         ds = load_dataset(
             ds_id,
@@ -141,8 +145,7 @@ def download_and_prepare_data(
         def normalize(doc):
             data = adapter(doc, transforms)
             data['prompt'] = ensure_user_first(data['prompt'])
-            if config.data_preparation.hf_include_source_id:
-                data.update({'source': ds_id})
+            data['source'] = source_key
 
             return data
 
@@ -197,7 +200,7 @@ def prepare_dpo_dataset(
     datasets_mix = copy.deepcopy(datasets_mix) if datasets_mix else copy.deepcopy(DEFAULT_DPO_MIX)
 
     #### VERIFY MIX FILE STRUCTURE
-    seed, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
+    seed, _, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
 
     download_and_prepare_data(
         config=config,

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -13,7 +13,8 @@ from datasets import (
 )
 from datasets_preparation.data_preparation_utils import (
     stable_hash,
-    assert_common_structure_and_extract
+    assert_common_structure_and_extract,
+    make_source_key
 )
 from datasets_preparation.default_mixes import DEFAULT_INSTRUCT_MIX
 from logger import logger
@@ -144,6 +145,7 @@ def download_and_prepare_data(
         max_messages = transforms.get('max_messages', 8)
 
         hf_name = None if name == 'default' else name
+        source_key = make_source_key(ds_id, name)
 
         ds = load_dataset(
             ds_id,
@@ -163,15 +165,10 @@ def download_and_prepare_data(
             conversation = conversation[:max_messages]
             conversation = trim_to_last_assistant(conversation)
 
-            result = {'conversation': []}
-            if config.data_preparation.hf_include_source_id:
-                result['source'] = ds_id
-
-            if not conversation:
-                return result
-
-            result['conversation'] = conversation
-            return result
+            return {
+                'conversation': conversation,
+                'source': source_key
+            }
 
         ds = ds.map(normalize, num_proc=num_proc)
         ds = ds.filter(lambda x: len(x['conversation']) > 0, num_proc=num_proc)
@@ -228,7 +225,7 @@ def prepare_instruct_dataset(
     datasets_mix = copy.deepcopy(datasets_mix) if datasets_mix else copy.deepcopy(DEFAULT_INSTRUCT_MIX)
 
     #### VERIFY MIX FILE STRUCTURE
-    seed, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
+    seed, _, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
 
     download_and_prepare_data(
         config=config,

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -9,9 +9,9 @@ from datasets import (
     interleave_datasets
 )
 from datasets_preparation.data_preparation_utils import (
-    stable_hash,
-    prepare_dataset,
-    assert_common_structure_and_extract
+    make_source_key,
+    assert_common_structure_and_extract,
+    shard_and_tokenize
 )
 from datasets_preparation.default_mixes import DEFAULT_PRETRAINING_MIX
 from logger import logger
@@ -70,6 +70,7 @@ def download_and_prepare_data(
         max_datapoints = transforms.get('max_datapoints', None)
 
         hf_name = None if name == 'default' else name
+        source_key = make_source_key(ds_id, name)
 
         ds = load_dataset(
             ds_id,
@@ -83,7 +84,6 @@ def download_and_prepare_data(
 
         if max_datapoints:
             max_datapoints = int(max_datapoints)
-            assert isinstance(max_datapoints, int)
             assert max_datapoints > 0
             ds = ds.take(max_datapoints)
 
@@ -92,18 +92,15 @@ def download_and_prepare_data(
             *,
             adapter=adapter,
             transforms=transforms,
-            ds_id=ds_id,
+            source_key=source_key
         ):
             batch = adapter(batch, transforms)
             texts = batch['text']
 
-            if config.data_preparation.hf_include_source_id:
-                return {
-                    'text': texts,
-                    'source': [ds_id] * len(texts),
-                }
-
-            return {'text': texts}
+            return {
+                'text': texts,
+                'source': [source_key] * len(texts)
+            }
 
         ds = ds.map(
             normalize,
@@ -126,24 +123,7 @@ def download_and_prepare_data(
     else:
         prepared_dataset = prepared_datasets[0]
 
-    # Split into train / val iterators. (no train_test_split with stream) The idea here is based in the law of large numbers (assuming we have enough datapoints).
-    # We want to draw datapoints and approach the proportions (probs) for train / val so. The hash is to make the assignment deterministic.
-    HASH_BYTES = 8
-    HASH_SPACE = 1 << (HASH_BYTES * 8) # 64 bit
-
-    VAL_FRACTION = 0.01
-    SEPARATION_THRESHOLD = int(VAL_FRACTION * HASH_SPACE)
-
-    def is_train(ex):
-        return stable_hash(ex['text'], seed=seed, hash_bytes=HASH_BYTES) >= SEPARATION_THRESHOLD
-
-    def is_val(ex):
-        return not is_train(ex)
-
-    train_ds = prepared_dataset.filter(is_train)
-    val_ds = prepared_dataset.filter(is_val)
-
-    return train_ds, val_ds
+    return prepared_dataset
 
 tokenizer = None
 def tokenize(tokenizer_kwargs, doc):
@@ -156,45 +136,6 @@ def tokenize(tokenizer_kwargs, doc):
     tokens_np[1:] = input_ids
     return tokens_np
 
-def shard_and_tokenize(
-    *,
-    config,
-    shard_size,
-    train_ds,
-    val_ds,
-    num_proc
-):
-    tokenizer_kwargs = {
-        'path': config.tokenizer.checkpoint_path,
-        'system_prompt': config.prompts.system_prompt,
-        'is_huggingface_tokenizer': config.tokenizer.huggingface_tokenizer,
-        'hf_token': config.third_party.hf_token if config.tokenizer.huggingface_tokenizer else None
-    }
-
-    logger.info('Preparing train dataset...')
-    prepare_dataset(
-        dataset=train_ds,
-        tokenize_function=tokenize,
-        tokenizer_kwargs=tokenizer_kwargs,
-        target_folder=os.path.join(config.paths.datasets.pretraining_path, 'train'),
-        shard_file_prefix='data',
-        shard_size=shard_size,
-        num_proc=num_proc,
-        chunksize=config.data_preparation.mp_pool_chunk_size
-    )
-
-    logger.info('Preparing val dataset...')
-    prepare_dataset(
-        dataset=val_ds,
-        tokenize_function=tokenize,
-        tokenizer_kwargs=tokenizer_kwargs,
-        target_folder=os.path.join(config.paths.datasets.pretraining_path, 'val'),
-        shard_file_prefix='data',
-        shard_size=shard_size,
-        num_proc=num_proc,
-        chunksize=config.data_preparation.mp_pool_chunk_size
-    )
-
 def prepare_pretraining_dataset(
     *,
     config,
@@ -203,24 +144,45 @@ def prepare_pretraining_dataset(
 ):
     datasets_mix = copy.deepcopy(datasets_mix) if datasets_mix else copy.deepcopy(DEFAULT_PRETRAINING_MIX)
 
-    assert 'shard_size' in datasets_mix
-    shard_size = datasets_mix['shard_size']
+    assert 'datasets_common_settings' in datasets_mix
+    assert 'shard_size' in datasets_mix['datasets_common_settings']
+    shard_size = datasets_mix['datasets_common_settings']['shard_size']
     assert isinstance(shard_size, int)
 
     #### VERIFY MIX FILE STRUCTURE
-    seed, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
+    seed, common_settings, valid_datasets, probabilities = assert_common_structure_and_extract(datasets_mix, SUPPORTED_HF_DATASETS)
 
-    train_ds, val_ds = download_and_prepare_data(
+    target_tokens = common_settings.get('target_tokens')
+    if target_tokens is not None:
+        target_tokens = int(target_tokens)
+
+    validation_ratio = float(common_settings.get('validation_ratio', 0.01))
+
+    prepared_dataset = download_and_prepare_data(
         config=config,
         seed=seed,
         valid_datasets=valid_datasets,
         probabilities=probabilities
     )
 
+    tokenizer_kwargs = {
+        'path': config.tokenizer.checkpoint_path,
+        'system_prompt': config.prompts.system_prompt,
+        'is_huggingface_tokenizer': config.tokenizer.huggingface_tokenizer,
+        'hf_token': config.third_party.hf_token if config.tokenizer.huggingface_tokenizer else None
+    }
+
     shard_and_tokenize(
-        config=config,
+        seed=seed,
+        dataset=prepared_dataset,
+        tokenize_function=tokenize,
+        tokenizer_kwargs=tokenizer_kwargs,
+        train_path=os.path.join(config.paths.datasets.pretraining_path, 'train'),
+        val_path=os.path.join(config.paths.datasets.pretraining_path, 'val'),
+        shard_file_prefix='data',
         shard_size=shard_size,
-        train_ds=train_ds,
-        val_ds=val_ds,
-        num_proc=num_proc
+        target_tokens=target_tokens,
+        validation_ratio=validation_ratio,
+        num_proc=num_proc,
+        chunksize=config.data_preparation.mp_pool_chunk_size
     )

--- a/datasets_preparation/prepare_recipe_data.py
+++ b/datasets_preparation/prepare_recipe_data.py
@@ -24,7 +24,7 @@ def prepare_recipe_data(recipe, num_proc):
         datasets_mix = data_config.model_dump(mode='python', exclude={'evals'}) # to be compatible with mix dict structure
 
         if config.training.stage == TrainingStage.PRETRAINING:
-            if data_config.shard_size is None:
+            if data_config.datasets_common_settings.shard_size is None:
                 raise ValueError('Pretraining recipes require data.shard_size.')
             prepare_pretraining_dataset(config=config, datasets_mix=datasets_mix, num_proc=num_proc)
         elif config.training.stage == TrainingStage.INSTRUCT:

--- a/examples/data_mixes/pretraining_data_mix.example.json
+++ b/examples/data_mixes/pretraining_data_mix.example.json
@@ -1,6 +1,8 @@
 {
     "seed": 42,
-    "shard_size": 100000000,
+    "datasets_common_settings": {
+        "shard_size": 100000000
+    },
     "datasets": {
         "HuggingFaceFW/fineweb-edu": {
             "sample-10BT": {

--- a/recipes/config.py
+++ b/recipes/config.py
@@ -7,6 +7,12 @@ from config import GlobalConfig
 from logger import logger
 
 
+class DatasetsCommonSettings(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    shard_size: int | None = None
+    target_tokens: int | None = None
+    validation_ratio: float = 0.01
+
 class DatasetEntryConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     weight: float
@@ -25,7 +31,7 @@ class RecipeEvalsDataConfig(BaseModel):
 class RecipeDataConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     seed: int
-    shard_size: int | None = None
+    datasets_common_settings: DatasetsCommonSettings = Field(default_factory=DatasetsCommonSettings)
     datasets: dict[str, dict[str, DatasetEntryConfig]] = Field(default_factory=dict)
     evals: RecipeEvalsDataConfig = Field(default_factory=RecipeEvalsDataConfig)
 

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -99,7 +99,8 @@ config:
 
 data:
   seed: 42
-  shard_size: 100000000
+  datasets_common_settings:
+    shard_size: 100000000
 
   datasets:
     HuggingFaceFW/fineweb-edu:

--- a/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
+++ b/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
@@ -102,7 +102,8 @@ config:
 
 data:
   seed: 42
-  shard_size: 100000000
+  datasets_common_settings:
+    shard_size: 100000000
 
   datasets:
     HuggingFaceTB/smollm-corpus:

--- a/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
+++ b/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
@@ -102,7 +102,8 @@ config:
 
 data:
   seed: 42
-  shard_size: 100000000
+  datasets_common_settings:
+    shard_size: 100000000
 
   datasets:
     HuggingFaceTB/smollm-corpus:

--- a/utils.py
+++ b/utils.py
@@ -50,8 +50,15 @@ def convert_byte_to_gib(byte_data):
     return round(byte_data / (1024 ** 3), 2)
 
 def load_json_file(file_path):
-    with open(file_path, 'r') as file:
+    file_path = Path(file_path)
+    with open(file_path, 'r', encoding='utf-8') as file:
         return json.load(file)
+
+def save_json_file(file_path, data):
+    file_path = Path(file_path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, 'w', encoding='utf-8') as file:
+        json.dump(data, file, ensure_ascii=False)
 
 def set_seed(seed: int, *, deterministic: bool = False):
     random.seed(seed)


### PR DESCRIPTION
Closes #7 

Main modifications:
- new config `datasets_common_settings` that contains properties `shard_size`, `target_tokens`, `validation_ratio`
  - This PR only uses them for pretraining prep;
- Complete refactoring of the process that tokenizes and creates the shards. We now use two objects responsible for writing the shards and the split logic happens during one pass (previously it was super inneficient as we did two passes). Also the code is easier to follow.
- The property `config.data_preparation.hf_include_source_id` is to be removed as source is now included in all datasets;
- Resume mechanism when failure happens.