### PR TITLE
adding estimation flag and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The project began with a decoder-only transformer baseline and has evolved into 
   - `trainer.py` The main implementation that orchestrates the entire training process.
   - `wandb.py` A wrapper for Weights & Biases.
     - Weights & Biases [here](https://wandb.ai/site/)
+  - `workload_estimation.py` Utilities to estimate token requirements for workload.
 - `evals/` Shared evaluation loading and scoring utilities.
   - Multiple choice evals:
     - HellaSwag
@@ -207,7 +208,7 @@ python prepare_datasets.py --recipe recipes/pretraining/debug.yaml
 python train.py --recipe recipes/pretraining/debug.yaml
 ```
 
-### Running the Training
+### Running training
 - To train on **single-GPU**, run:
     ```bash
     python train.py --recipe recipes/pretraining/debug.yaml
@@ -303,6 +304,44 @@ python train.py --recipe recipes/pretraining/debug.yaml
 
 - More details on torchrun [here](https://pytorch.org/docs/stable/elastic/run.html)
 - More details on NCCL [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#environment-variables)
+
+### Running generation
+- For all options: `python generate.py --help`
+- Example:
+    ```bash
+    python generate.py \
+      --checkpoint <CHECKPOINT_FILE_PATH> \
+      --prompts examples/prompts/pretraining.example.json \
+      --max-gen-len 160 \
+      --temperature 0.0 \
+      --top-p 0.9 \
+      --device cuda \
+      --dtype bf16 \
+      --seed 42 \
+      --batch-size 4 \
+      --use-kv-cache \
+      --output-file-name <OUTPUT_FILE_PATH>
+    ```
+
+### Running evals
+- For all options: `python evaluate.py --help`
+- Example:
+    ```bash
+    python evaluate.py \
+      --checkpoint  <CHECKPOINT_FILE_PATH> \
+      --validation \
+      --validation-steps 1000 \
+      --hellaswag \
+      --hellaswag-examples 100 \
+      --winogrande \
+      --winogrande-examples 100 \
+      --arc-challenge \
+      --arc-challenge-examples 100 \
+      --batch-size 4 \
+      --device cuda \
+      --dtype bf16 \
+      --output-file-name <OUTPUT_FILE_PATH>
+    ```
 
 ## Using Torch Profiler
 Torch profiler settings are configured in `config.py` under `GlobalConfig.torch_profiler`.

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -5,6 +5,7 @@ from engine.checkpoints import CheckpointData
 from engine.context import TrainerContext
 from engine.optim import OptimizerPlan
 from engine.core import TrainerState
+from engine.workload_estimation import estimate_workload_tokens
 from metrics.memory import MemoryUsageMetrics
 from metrics.step import (
     StepType,
@@ -24,34 +25,14 @@ def prepare_workload_summary(
     model_trainable_params_count: int,
     total_tokens: int
 ):
-    if config.training.stage == TrainingStage.PRETRAINING or config.training.stage == TrainingStage.INSTRUCT:
-        # For pretraining according to the Chinchilla paper ~20.0 is reasonable. For instruct: ~0.2 to ~0.5 is reasonable
-        m_factor = 20.0 if config.training.stage == TrainingStage.PRETRAINING else 0.3
-        tokens_required_for_model_size = int(model_params_count * m_factor)
-        steps_needed = math.ceil(tokens_required_for_model_size / config.training.total_batch_size)
-        tokens_per_step = config.training.total_batch_size
-        tokens_coverage = trainer_state.max_steps * tokens_per_step
-        dataset_fraction = tokens_coverage / total_tokens if total_tokens > 0 else None
-
-        derived = {
-            'model_params_count': model_params_count,
-            'model_trainable_params_count': model_trainable_params_count,
-            'total_tokens': total_tokens,
-            'm_factor': m_factor,
-            'tokens_required_for_model_size': tokens_required_for_model_size,
-            'dataset_covers_heuristic': (total_tokens >= tokens_required_for_model_size),
-            'steps_needed_for_target': steps_needed,
-            'tokens_per_step': tokens_per_step,
-            'tokens_processed_this_run': tokens_coverage,
-            'dataset_coverage_ratio': round(dataset_fraction, 2),
-            'max_steps_covers_heuristic': (trainer_state.max_steps >= steps_needed)
-        }
-    else:
-        derived = {
-            'model_params_count': model_params_count,
-            'model_trainable_params_count': model_trainable_params_count,
-            'total_tokens': total_tokens
-        }
+    derived = estimate_workload_tokens(
+        stage=config.training.stage,
+        model_params_count=model_params_count,
+        model_trainable_params_count=model_trainable_params_count,
+        total_tokens=total_tokens,
+        total_batch_size=config.training.total_batch_size,
+        max_steps=trainer_state.max_steps
+    )
 
     summary = {
         'config': config.model_dump(),

--- a/engine/workload_estimation.py
+++ b/engine/workload_estimation.py
@@ -1,0 +1,112 @@
+import math
+
+from config import GlobalConfig, TrainingStage
+from tokenization.tokenizer import init_tokenizer
+from models.registry import build_model
+from logger import logger
+
+
+def get_stage_token_multiplier(stage: TrainingStage) -> float | None:
+    # For pretraining according to the Chinchilla paper ~20.0 is reasonable.
+    if stage == TrainingStage.PRETRAINING:
+        return 20.0
+    # For instruct: ~0.2 to ~0.5 is reasonable.
+    if stage == TrainingStage.INSTRUCT:
+        return 0.3
+    return None
+
+def estimate_workload_tokens(
+    *,
+    stage: TrainingStage,
+    model_params_count: int,
+    model_trainable_params_count: int | None = None,
+    total_tokens: int | None = None,
+    total_batch_size: int | None = None,
+    max_steps: int | None = None,
+    m_factor: float | None = None,
+):
+    if m_factor is None:
+        m_factor = get_stage_token_multiplier(stage)
+
+    derived = {
+        'model_params_count': model_params_count,
+        'model_trainable_params_count': model_trainable_params_count,
+        'total_tokens': total_tokens,
+    }
+
+    if m_factor is None:
+        return derived
+
+    tokens_required_for_model_size = int(model_params_count * m_factor)
+
+    derived.update({
+        'm_factor': m_factor,
+        'tokens_required_for_model_size': tokens_required_for_model_size,
+        'dataset_covers_heuristic': (
+            total_tokens >= tokens_required_for_model_size
+            if total_tokens is not None
+            else None
+        ),
+    })
+
+    if total_batch_size is not None:
+        steps_needed = math.ceil(tokens_required_for_model_size / total_batch_size)
+
+        derived.update({
+            'steps_needed_for_target': steps_needed,
+            'tokens_per_step': total_batch_size,
+        })
+
+    if max_steps is not None and total_batch_size is not None:
+        tokens_coverage = max_steps * total_batch_size
+
+        dataset_fraction = (
+            tokens_coverage / total_tokens
+            if total_tokens is not None and total_tokens > 0
+            else None
+        )
+
+        derived.update({
+            'tokens_processed_this_run': tokens_coverage,
+            'dataset_coverage_ratio': (
+                round(dataset_fraction, 2)
+                if dataset_fraction is not None
+                else None
+            ),
+            'max_steps_covers_heuristic': (
+                max_steps >= derived['steps_needed_for_target']
+                if 'steps_needed_for_target' in derived
+                else None
+            ),
+        })
+
+    return derived
+
+def estimate_workload_tokens_from_config(config: GlobalConfig):
+    tokenizer = init_tokenizer(
+        path=config.tokenizer.checkpoint_path,
+        system_prompt=config.prompts.system_prompt,
+        is_huggingface_tokenizer=config.tokenizer.huggingface_tokenizer,
+        hf_token=config.third_party.hf_token if config.tokenizer.huggingface_tokenizer else None
+    )
+    model = build_model(
+        config=config.model,
+        pad_token_id=tokenizer.pad_id,
+        vocab_size=tokenizer.vocab_size,
+        ignore_index=config.tokenizer.ignore_index
+    )
+    derived = estimate_workload_tokens(
+        stage=config.training.stage,
+        model_params_count=model.get_total_parameters_count(),
+        model_trainable_params_count=model.get_trainable_parameters_count()
+    )
+
+    result = {
+        'model_params_count': f"{derived['model_params_count']:,}",
+        'model_trainable_params_count': f"{derived['model_trainable_params_count']:,}",
+        'm_factor': derived['m_factor'],
+        'tokens_required_for_model_size': f"{derived['tokens_required_for_model_size']:,}"
+    }
+
+    logger.section('Target token count estimation')
+    logger.info(result, is_json=True)

--- a/prepare_datasets.py
+++ b/prepare_datasets.py
@@ -3,7 +3,7 @@ import argparse
 import json
 
 from logger import logger
-from config import load_config
+from config import load_config, TrainingStage
 from utils import load_json_file
 from recipes.config import load_recipe
 from datasets_preparation.data_preparation_utils import get_max_number_of_cpu_processes
@@ -26,16 +26,16 @@ if __name__ == '__main__':
     config_group.add_argument('--config', type=str, default=None, help='Path to the configuration definition (.yaml). If not provided, default values are used.')
     config_group.add_argument('--recipe', type=str, default=None, help='Path to a recipe YAML file.')
 
-    dataset_group = parser.add_mutually_exclusive_group()
-    dataset_group.add_argument('--hellaswag', action='store_true', help='Prepare HellaSwag eval dataset')
-    dataset_group.add_argument('--winogrande', action='store_true', help='Prepare WinoGrande eval dataset')
-    dataset_group.add_argument('--arc-challenge', action='store_true', help='Prepare ARC-Challenge eval dataset')
-    dataset_group.add_argument('--pretraining', action='store_true', help='Prepare pretraining dataset')
-    dataset_group.add_argument('--instruct', action='store_true', help='Prepare instruct (SFT) dataset')
-    dataset_group.add_argument('--dpo', action='store_true', help='Prepare DPO (Direct Preference Optimization) dataset')
+    action_group = parser.add_mutually_exclusive_group()
+    action_group.add_argument('--hellaswag', action='store_true', help='Prepare HellaSwag eval dataset')
+    action_group.add_argument('--winogrande', action='store_true', help='Prepare WinoGrande eval dataset')
+    action_group.add_argument('--arc-challenge', action='store_true', help='Prepare ARC-Challenge eval dataset')
+    action_group.add_argument('--pretraining', action='store_true', help='Prepare pretraining dataset')
+    action_group.add_argument('--instruct', action='store_true', help='Prepare instruct (SFT) dataset')
+    action_group.add_argument('--dpo', action='store_true', help='Prepare DPO (Direct Preference Optimization) dataset')
+    action_group.add_argument('--estimate-token-target', action='store_true', help='Estimates the token count required for the current model configuration')
 
     parser.add_argument('--mix-file', type=str, default=None, help='Path to custom mix file')
-    parser.add_argument('--estimate-token-target', action='store_true', help='Estimates the token count required for the current model configuration')
 
     args = parser.parse_args()
 
@@ -48,22 +48,31 @@ if __name__ == '__main__':
         args.dpo
     )
 
+    action_group_flags_set = (
+        dataset_group_flags_set or
+        args.estimate_token_target
+    )
+
     if args.recipe and (dataset_group_flags_set or args.mix_file):
-        parser.error('--recipe defines the data configuration. Cannot combine --recipe with any other flag.')
+        parser.error(
+            '--recipe defines the data configuration. Cannot combine --recipe '
+            'with dataset preparation flags or --mix-file.'
+        )
 
-    # if args.estimate_token_target and not (args.pretraining or args.instruct):
-    #     parser.error('--estimate-token-target can only be used when preparing pretraining or instruct datasets.')
+    if args.estimate_token_target and args.mix_file:
+        parser.error('--estimate-token-target cannot be combined with --mix-file.')
 
-    # estimate_workload_tokens_from_config
     if args.recipe:
         recipe = load_recipe(args.recipe)
         cfg = recipe.config
     else:
-        if not dataset_group_flags_set:
-            parser.error('Please specify one dataset flag, or use --recipe.')
+        if not action_group_flags_set:
+            parser.error('Please specify one dataset flag/action, or use --recipe.')
         cfg = load_config(args.config)
 
     if args.estimate_token_target:
+        if cfg.training.stage == TrainingStage.DPO:
+            parser.error('--estimate-token-target is not supported for DPO.')
         estimate_workload_tokens_from_config(config=cfg)
         sys.exit(0)
 

--- a/prepare_datasets.py
+++ b/prepare_datasets.py
@@ -1,3 +1,4 @@
+import sys
 import argparse
 import json
 
@@ -13,6 +14,7 @@ from datasets_preparation.prepare_pretraining_dataset import prepare_pretraining
 from datasets_preparation.prepare_instruct_dataset import prepare_instruct_dataset
 from datasets_preparation.prepare_dpo_dataset import prepare_dpo_dataset
 from datasets_preparation.prepare_recipe_data import prepare_recipe_data
+from engine.workload_estimation import estimate_workload_tokens_from_config
 
 
 if __name__ == '__main__':
@@ -33,6 +35,7 @@ if __name__ == '__main__':
     dataset_group.add_argument('--dpo', action='store_true', help='Prepare DPO (Direct Preference Optimization) dataset')
 
     parser.add_argument('--mix-file', type=str, default=None, help='Path to custom mix file')
+    parser.add_argument('--estimate-token-target', action='store_true', help='Estimates the token count required for the current model configuration')
 
     args = parser.parse_args()
 
@@ -48,19 +51,27 @@ if __name__ == '__main__':
     if args.recipe and (dataset_group_flags_set or args.mix_file):
         parser.error('--recipe defines the data configuration. Cannot combine --recipe with any other flag.')
 
+    # if args.estimate_token_target and not (args.pretraining or args.instruct):
+    #     parser.error('--estimate-token-target can only be used when preparing pretraining or instruct datasets.')
+
+    # estimate_workload_tokens_from_config
     if args.recipe:
         recipe = load_recipe(args.recipe)
-        prepare_recipe_data(
-            recipe=recipe,
-            num_proc=get_max_number_of_cpu_processes(recipe.config)
-        )
+        cfg = recipe.config
     else:
         if not dataset_group_flags_set:
             parser.error('Please specify one dataset flag, or use --recipe.')
-
         cfg = load_config(args.config)
-        num_proc = get_max_number_of_cpu_processes(cfg)
 
+    if args.estimate_token_target:
+        estimate_workload_tokens_from_config(config=cfg)
+        sys.exit(0)
+
+    num_proc = get_max_number_of_cpu_processes(cfg)
+
+    if args.recipe:
+        prepare_recipe_data(recipe=recipe, num_proc=num_proc)
+    else:
         if (args.hellaswag or args.winogrande or args.arc_challenge) and args.mix_file:
             parser.error('"--mix-file" is only supported for training datasets.')
 


### PR DESCRIPTION
Changes:
- adds `--estimate-token-target` flag to data prep. This will work for pretraining/instruct and gives console output for example:
    ``` 
    Target token count estimation:
    ----------------------------------------
    {
        "model_params_count": "179,341,056",
        "model_trainable_params_count": "179,341,056",
        "m_factor": 20.0,
        "tokens_required_for_model_size": "3,586,821,120"
    }
    ```
- Moved the old estimator that was in `engine.logging.py` to its own file. Refactored the code so it can be reused by data prep.
- Updated README;