### PR TITLE
Tracking the best checkpoint in different dir

### DIFF
--- a/config.py
+++ b/config.py
@@ -203,6 +203,7 @@ class CheckpointingConfig(BaseModel):
     save_checkpoints: bool = False
     every_x_steps: int = 50
     max_number_checkpoints: int = 5
+    max_number_best_checkpoints: int = 1
     run_on_first_step: bool = False
     run_on_last_step: bool = False
 

--- a/config.py
+++ b/config.py
@@ -201,7 +201,6 @@ class ValidationConfig(BaseModel):
 class CheckpointingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     save_checkpoints: bool = False
-    save_best_only: bool = False
     every_x_steps: int = 50
     max_number_checkpoints: int = 5
     run_on_first_step: bool = False

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -113,7 +113,7 @@ def save_checkpoint(
 
         if is_best:
             best_checkpoint_dir = os.path.join(checkpoint_dir, 'best')
-            best_checkpoint_path = os.path.join(best_checkpoint_dir, f'best_model.pt')
+            best_checkpoint_path = os.path.join(best_checkpoint_dir, f'model.pt')
             os.makedirs(best_checkpoint_dir, exist_ok=True)
             torch.save(checkpoint, best_checkpoint_path)
             logger.info(f'{step:4d} | saved best checkpoint: {best_checkpoint_path}', pbar=pbar)

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -61,6 +61,7 @@ def save_checkpoint(
     extra_metadata,
     max_number_checkpoints,
     is_master_process,
+    is_best=False,
     pbar=None
 ):
     optimizer_state = {'adamw': None, 'muon': None}
@@ -109,6 +110,13 @@ def save_checkpoint(
 
         torch.save(checkpoint, checkpoint_path)
         logger.info(f'{step:4d} | saved checkpoint: {checkpoint_path}', pbar=pbar)
+
+        if is_best:
+            best_checkpoint_dir = os.path.join(checkpoint_dir, 'best')
+            best_checkpoint_path = os.path.join(best_checkpoint_dir, f'best_model.pt')
+            os.makedirs(best_checkpoint_dir, exist_ok=True)
+            torch.save(checkpoint, best_checkpoint_path)
+            logger.info(f'{step:4d} | saved best checkpoint: {best_checkpoint_path}', pbar=pbar)
 
         manage_checkpoints(directory=checkpoint_dir, max_files=max_number_checkpoints, step=step, pbar=pbar)
 

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -61,7 +61,6 @@ def save_checkpoint(
     extra_metadata,
     max_number_checkpoints,
     is_master_process,
-    is_best=False,
     pbar=None
 ):
     optimizer_state = {'adamw': None, 'muon': None}
@@ -110,13 +109,6 @@ def save_checkpoint(
 
         torch.save(checkpoint, checkpoint_path)
         logger.info(f'{step:4d} | saved checkpoint: {checkpoint_path}', pbar=pbar)
-
-        if is_best:
-            best_checkpoint_dir = os.path.join(checkpoint_dir, 'best')
-            best_checkpoint_path = os.path.join(best_checkpoint_dir, f'model.pt')
-            os.makedirs(best_checkpoint_dir, exist_ok=True)
-            torch.save(checkpoint, best_checkpoint_path)
-            logger.info(f'{step:4d} | saved best checkpoint: {best_checkpoint_path}', pbar=pbar)
 
         manage_checkpoints(directory=checkpoint_dir, max_files=max_number_checkpoints, step=step, pbar=pbar)
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -970,10 +970,7 @@ class Trainer:
         )
 
     def run_save_checkpoint(self, pbar=None):
-        if (
-            not self.config.checkpointing.save_checkpoints or
-            (self.config.checkpointing.save_best_only and self.trainer_state.num_val_runs_no_improve > 0)
-        ):
+        if not self.config.checkpointing.save_checkpoints:
             return
 
         logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
@@ -994,6 +991,7 @@ class Trainer:
             },
             self.config.checkpointing.max_number_checkpoints,
             self.distributed_ctx.is_master_process,
+            is_best=(self.trainer_state.num_val_runs_no_improve == 0),
             pbar=pbar
         )
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -177,6 +177,9 @@ class Trainer:
     def get_checkpoints_dir_path(self):
         return self.get_run_output_dir_path() / 'checkpoints'
 
+    def get_best_checkpoints_dir_path(self):
+        return self.get_run_output_dir_path() / 'checkpoints' / 'best'
+
     def get_snapshots_dir_path(self):
         return self.get_run_output_dir_path() / 'snapshots'
 
@@ -939,6 +942,7 @@ class Trainer:
         if self.trainer_state.last_val_loss < self.trainer_state.best_val_loss:
             self.trainer_state.best_val_loss = self.trainer_state.last_val_loss
             self.trainer_state.num_val_runs_no_improve = 0
+            self.run_save_best_checkpoint(pbar)
         else:
             skip_phase = (self.trainer_state.current_step < early_stopping_patience_skip_steps)
             if not skip_phase:
@@ -969,13 +973,9 @@ class Trainer:
             pbar=pbar
         )
 
-    def run_save_checkpoint(self, pbar=None):
-        if not self.config.checkpointing.save_checkpoints:
-            return
-
-        logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
+    def run_save_checkpoint(self, *, path, max_number_checkpoints, pbar):
         save_checkpoint(
-            self.get_checkpoints_dir_path(),
+            path,
             get_model(self.model),
             self.config,
             self.trainer_state.current_step,
@@ -989,9 +989,28 @@ class Trainer:
                 'lora_enabled': self.config.lora.enabled,
                 'ddp_world_size': self.distributed_ctx.ddp_world_size
             },
-            self.config.checkpointing.max_number_checkpoints,
+            max_number_checkpoints,
             self.distributed_ctx.is_master_process,
-            is_best=(self.trainer_state.num_val_runs_no_improve == 0),
+            pbar=pbar
+        )
+
+    def run_save_common_checkpoint(self, pbar=None):
+        if not self.config.checkpointing.save_checkpoints:
+            return
+        logger.info(f'{self.trainer_state.current_step:4d} | saving checkpoint...', pbar=pbar)
+        self.run_save_checkpoint(
+            path=self.get_checkpoints_dir_path(),
+            max_number_checkpoints=self.config.checkpointing.max_number_checkpoints,
+            pbar=pbar
+        )
+
+    def run_save_best_checkpoint(self, pbar=None):
+        if not self.config.checkpointing.save_checkpoints:
+            return
+        logger.info(f'{self.trainer_state.current_step:4d} | saving best checkpoint...', pbar=pbar)
+        self.run_save_checkpoint(
+            path=self.get_best_checkpoints_dir_path(),
+            max_number_checkpoints=self.config.checkpointing.max_number_best_checkpoints,
             pbar=pbar
         )
 
@@ -1107,7 +1126,7 @@ class Trainer:
         if self.should_run(run_config=self.config.validation):
             self.run_validation(pbar)
         if self.should_run(run_config=self.config.checkpointing):
-            self.run_save_checkpoint(pbar)
+            self.run_save_common_checkpoint(pbar)
         if self.should_run(run_config=self.config.evals.hellaswag):
             self.run_hellaswag_eval(pbar)
         if self.should_run(run_config=self.config.evals.winogrande):

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -73,7 +73,6 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    save_best_only: false
     every_x_steps: -1
     max_number_checkpoints: 5
     run_on_first_step: true

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -73,7 +73,6 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    save_best_only: false
     every_x_steps: -1
     max_number_checkpoints: 5
     run_on_first_step: true

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -91,7 +91,6 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    save_best_only: false
     every_x_steps: -1
     max_number_checkpoints: 5
     run_on_first_step: true

--- a/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
+++ b/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
@@ -91,7 +91,6 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    save_best_only: false
     every_x_steps: -1
     max_number_checkpoints: 3
     run_on_first_step: true

--- a/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
+++ b/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
@@ -91,7 +91,6 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    save_best_only: false
     every_x_steps: 250
     max_number_checkpoints: 3
     run_on_first_step: true


### PR DESCRIPTION
Closes #56 

Changes:
- Removed the config to save best only;
- Be default we will now keep track of the best checkpoint under `checkpoints/best/`;
- New property: `max_number_best_checkpoints`
- NOTE: Old checkpoints break with this change;