### PR TITLE
Adding support for instruct ds; start step and max steps config for schedulers

### DIFF
--- a/config.py
+++ b/config.py
@@ -161,6 +161,8 @@ class AdamWConfig(BaseModel):
     betas: tuple[float, float] = (0.9, 0.95)
     use_fused: bool | None = None
     warmup_steps: int = 20
+    scheduler_start_step: int = 0
+    scheduler_max_steps: int | None = None
 
 class MuonConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -170,6 +172,8 @@ class MuonConfig(BaseModel):
     weight_decay: float = 0.0
     momentum: float = 0.95
     warmup_steps: int = 20
+    scheduler_start_step: int = 0
+    scheduler_max_steps: int | None = None
 
 class OptimizersConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -63,6 +63,22 @@ def adapt_lmsys_chat_1m(doc, transforms, seed):
         conversation.append({'role': message['role'], 'content': content})
     return conversation
 
+def adapt_tulu_3_sft_personas_instruction_following(doc, transforms, seed):
+    messages = doc['messages']
+    conversation = []
+    for message in messages:
+        conversation.append({'role': message['role'], 'content': message['content']})
+    return conversation
+
+def adapt_grammarly_coedit(doc, transforms, seed):
+    src = doc['src']
+    tgt = doc['tgt']
+    conversation = [
+        {'role': 'user', 'content': src},
+        {'role': 'assistant', 'content': tgt}
+    ]
+    return conversation
+
 #### SUPPORTED DATASETS
 SUPPORTED_HF_DATASETS = {
     'HuggingFaceH4/ultrachat_200k': {
@@ -77,6 +93,20 @@ SUPPORTED_HF_DATASETS = {
             'id': 'lmsys/lmsys-chat-1m',
             'split': 'train',
             'adapter': adapt_lmsys_chat_1m
+        }
+    },
+    'allenai/tulu-3-sft-personas-instruction-following': {
+        'default': {
+            'id': 'allenai/tulu-3-sft-personas-instruction-following',
+            'split': 'train',
+            'adapter': adapt_tulu_3_sft_personas_instruction_following
+        }
+    },
+    'grammarly/coedit': {
+        'default': {
+            'id': 'grammarly/coedit',
+            'split': 'train',
+            'adapter': adapt_grammarly_coedit
         }
     }
 }

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -181,9 +181,6 @@ def load_checkpoint(file_path) -> CheckpointData:
     logger.section('Loaded config')
     logger.info(state['config'], is_json=True)
 
-    logger.section('Loaded model config')
-    logger.info(state['config'], is_json=True)
-
     if step > 0:
         logger.info(f'\nResuming from step: {step}')
     else:

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -98,11 +98,22 @@ def prepare_train_step_log(
 
     train_loss = aggregated_metrics['Train Loss']
 
-    adam_lr = step_metrics.lrs.get('adamw_lr', None)
-    muon_lr = step_metrics.lrs.get('muon_lr', None)
-    lr_console_message = f'lr (adamw): {adam_lr:.4e}'
-    if muon_lr:
-        lr_console_message = f'lr (adamw/muon): {adam_lr:.4e} / {muon_lr:.4e}'
+    adamw_metadata = step_metrics.scheduler_metadata.get('adamw', None)
+    muon_metadata = step_metrics.scheduler_metadata.get('muon', None)
+
+    adam_lr = adamw_metadata.get('lr', None)
+    adamw_scheduler_step = adamw_metadata.get('scheduler_step', None)
+    adamw_scheduler_max_steps = adamw_metadata.get('scheduler_max_steps', None)
+    scheduler_console_message = f'sched (adamw): step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e}'
+    muon_lr = None
+    if muon_metadata and muon_metadata.get('lr', None):
+        muon_lr = muon_metadata.get('lr', None)
+        muon_scheduler_step = muon_metadata.get('scheduler_step', None)
+        muon_scheduler_max_steps = muon_metadata.get('scheduler_max_steps', None)
+        scheduler_console_message = (
+            f'(adamw): step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e} | '
+            f'(muon): step {muon_scheduler_step}/{muon_scheduler_max_steps} lr {muon_lr:.4e}'
+        )
     norm = step_metrics.norm
     dt = step_metrics.dt
     tokens_per_sec = step_metrics.tokens_per_sec
@@ -117,11 +128,11 @@ def prepare_train_step_log(
     console_log = (
         f'{step:4d} | '
         f'train loss: {train_loss:.4f} | '
-        f'val (last/best): {last_val_loss:.4f} / {best_val_loss:.4f} | '
-        f'{lr_console_message} | '
+        f'val loss (last/best): {last_val_loss:.4f} / {best_val_loss:.4f} | '
         f'norm: {norm:.4f} | '
         f'dt: {dt:.2f}s | '
         f'tok/s: {int(tokens_per_sec)}'
+        f'\n       {scheduler_console_message}'
         f'\n       mem MiB current alloc/res: {current_allocated_mb:.0f} / {current_reserved_mb:.0f} | '
         f'peak alloc/res: {peak_allocated_mb:.0f} / {peak_reserved_mb:.0f}'
         f'{dpo_console_message}'

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -770,7 +770,15 @@ class Trainer:
         return max(0, current_step - scheduler_start_step)
 
     def resolve_scheduler_max_steps(self, max_steps, scheduler_start_step, scheduler_max_steps):
-        return scheduler_max_steps if scheduler_max_steps is not None else max_steps - scheduler_start_step
+        resolved = scheduler_max_steps if scheduler_max_steps is not None else max_steps - scheduler_start_step
+        if resolved <= 0:
+            raise ValueError(
+                f'Invalid scheduler_max_steps: {resolved} '
+                f'max_steps: {max_steps}, '
+                f'scheduler_start_step: {scheduler_start_step}, '
+                f'configured scheduler_max_steps: {scheduler_max_steps}'
+            )
+        return resolved
 
     def update_optimizers_lr(self):
         lrs = {}

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -766,14 +766,26 @@ class Trainer:
         if self.optimizers.muon:
             scaler.unscale_(self.optimizers.muon)
 
+    def resolve_scheduler_step(self, current_step, scheduler_start_step):
+        return max(0, current_step - scheduler_start_step)
+
+    def resolve_scheduler_max_steps(self, max_steps, scheduler_start_step, scheduler_max_steps):
+        return scheduler_max_steps if scheduler_max_steps is not None else max_steps - scheduler_start_step
+
     def update_optimizers_lr(self):
-        step = self.trainer_state.current_step
         lrs = {}
         if self.optimizers.adamw:
             adamw_lr = cosine_scheduler(
-                step=step,
+                step=self.resolve_scheduler_step(
+                    self.trainer_state.current_step,
+                    self.config.optimizers.adamw.scheduler_start_step
+                ),
                 warmup_steps=self.config.optimizers.adamw.warmup_steps,
-                max_steps=self.trainer_state.max_steps,
+                max_steps=self.resolve_scheduler_max_steps(
+                    self.trainer_state.max_steps,
+                    self.config.optimizers.adamw.scheduler_start_step,
+                    self.config.optimizers.adamw.scheduler_max_steps
+                ),
                 max_lr=self.config.optimizers.adamw.max_lr,
                 min_lr=self.config.optimizers.adamw.min_lr,
             )
@@ -783,9 +795,16 @@ class Trainer:
             lrs['adamw_lr'] = adamw_lr
         if self.optimizers.muon:
             muon_lr = cosine_scheduler(
-                step=step,
+                step=self.resolve_scheduler_step(
+                    self.trainer_state.current_step,
+                    self.config.optimizers.muon.scheduler_start_step
+                ),
                 warmup_steps=self.config.optimizers.muon.warmup_steps,
-                max_steps=self.trainer_state.max_steps,
+                max_steps=self.resolve_scheduler_max_steps(
+                    self.trainer_state.max_steps,
+                    self.config.optimizers.muon.scheduler_start_step,
+                    self.config.optimizers.muon.scheduler_max_steps
+                ),
                 max_lr=self.config.optimizers.muon.max_lr,
                 min_lr=self.config.optimizers.muon.min_lr,
             )

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -781,46 +781,58 @@ class Trainer:
         return resolved
 
     def update_optimizers_lr(self):
-        lrs = {}
+        scheduler_metadata = {}
         if self.optimizers.adamw:
+            adamw_scheduler_step = self.resolve_scheduler_step(
+                self.trainer_state.current_step,
+                self.config.optimizers.adamw.scheduler_start_step
+            )
+            adamw_scheduler_max_steps = self.resolve_scheduler_max_steps(
+                self.trainer_state.max_steps,
+                self.config.optimizers.adamw.scheduler_start_step,
+                self.config.optimizers.adamw.scheduler_max_steps
+            )
             adamw_lr = cosine_scheduler(
-                step=self.resolve_scheduler_step(
-                    self.trainer_state.current_step,
-                    self.config.optimizers.adamw.scheduler_start_step
-                ),
+                step=adamw_scheduler_step,
                 warmup_steps=self.config.optimizers.adamw.warmup_steps,
-                max_steps=self.resolve_scheduler_max_steps(
-                    self.trainer_state.max_steps,
-                    self.config.optimizers.adamw.scheduler_start_step,
-                    self.config.optimizers.adamw.scheduler_max_steps
-                ),
+                max_steps=adamw_scheduler_max_steps,
                 max_lr=self.config.optimizers.adamw.max_lr,
                 min_lr=self.config.optimizers.adamw.min_lr,
             )
             for group in self.optimizers.adamw.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)
                 group['lr'] = adamw_lr * lr_scale
-            lrs['adamw_lr'] = adamw_lr
+            scheduler_metadata['adamw'] = {
+                'lr': adamw_lr,
+                'scheduler_step': adamw_scheduler_step,
+                'scheduler_max_steps': adamw_scheduler_max_steps
+            }
         if self.optimizers.muon:
+            muon_scheduler_step = self.resolve_scheduler_step(
+                self.trainer_state.current_step,
+                self.config.optimizers.muon.scheduler_start_step
+            )
+            muon_scheduler_max_steps = self.resolve_scheduler_max_steps(
+                self.trainer_state.max_steps,
+                self.config.optimizers.muon.scheduler_start_step,
+                self.config.optimizers.muon.scheduler_max_steps
+            )
             muon_lr = cosine_scheduler(
-                step=self.resolve_scheduler_step(
-                    self.trainer_state.current_step,
-                    self.config.optimizers.muon.scheduler_start_step
-                ),
+                step=muon_scheduler_step,
                 warmup_steps=self.config.optimizers.muon.warmup_steps,
-                max_steps=self.resolve_scheduler_max_steps(
-                    self.trainer_state.max_steps,
-                    self.config.optimizers.muon.scheduler_start_step,
-                    self.config.optimizers.muon.scheduler_max_steps
-                ),
+                max_steps=muon_scheduler_max_steps,
                 max_lr=self.config.optimizers.muon.max_lr,
                 min_lr=self.config.optimizers.muon.min_lr,
             )
             for group in self.optimizers.muon.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)
                 group['lr'] = muon_lr * lr_scale
-            lrs['muon_lr'] = muon_lr
-        return lrs
+            scheduler_metadata['muon'] = {
+                'lr': muon_lr,
+                'scheduler_step': muon_scheduler_step,
+                'scheduler_max_steps': muon_scheduler_max_steps
+            }
+        return scheduler_metadata
 
     def optimizers_steps(self, scaler):
         if scaler:
@@ -887,7 +899,7 @@ class Trainer:
 
         norm = self.clip_grad_norm(self.model, 1.0)
 
-        lrs = self.update_optimizers_lr()
+        scheduler_metadata = self.update_optimizers_lr()
         self.optimizers_steps(scaler)
         self.zero_grad_optimizers()
 
@@ -901,7 +913,7 @@ class Trainer:
             norm=norm,
             dt=dt,
             tokens_per_sec=tokens_per_sec,
-            lrs=lrs
+            scheduler_metadata=scheduler_metadata
         )
         aggregated_metrics = combine_weighted_metrics(
             metrics_sum_acc=metrics_sum_acc,

--- a/metrics/step.py
+++ b/metrics/step.py
@@ -15,5 +15,5 @@ class StepMetrics:
     norm: float = None
     dt: float = None
     tokens_per_sec: int = None
-    lrs: dict[str, float] = None
+    scheduler_metadata: dict[str, dict] = None
     accuracy: float = None


### PR DESCRIPTION
Changes:
- optimizers schedulers step configs (start step, max step);
- scheduler step is derived relative to the global `current_step`;
- fix double logging on checkpoint load;
- added support for hf instruct ds: `allenai/tulu-3-sft-personas-instruction-following` and `grammarly/coedit`