### PR TITLE
Warmup stable decay scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ The project began with a decoder-only transformer baseline and has evolved into 
 - `cli/` Common cli related logic.
 - `datasets_preparation/` Components used for downloading, preparing, and tokenizing datasets.
 - `engine/` Trainer and runtime core components. The main ones are:
+  - `dataloaders/` Dataloader logic for sampling and distributing data.
   - `checkpoints.py` Logic to handle checkpointing.
   - `context.py` Defines context transport classes.
   - `core.py` Defines state object used by the trainer.
-  - `dataloaders.py` Dataloader logic for sampling and distributing data.
   - `distributed.py` Contains the main logic to set up the PyTorch DDP (Distributed Data Parallel) and FSDP2 (Fully Sharded Data Parallel).
     - PyTorch DDP [here](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html)
   - `logging.py` Handles different logging tasks used in the trainer.
-  - `lr_schedulers.py` Stores learning rate schedulers. At the moment, it includes a cosine scheduler.
+  - `lr_schedulers.py` Stores learning rate schedulers. At the moment, it includes a cosine and WSD schedulers.
   - `optim.py` Defines and controls the optimizer(s) setup. Also has the necessary logic to build the parameter groups.
   - `snapshot.py` Implements the logic to create and store the setup snapshot.
   - `torch_profiler.py` Adds torch profiler logic and context manager.

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, ConfigDict
 from pydantic_settings import BaseSettings
 from enum import Enum
-from typing import Any, Annotated
+from typing import Any, Annotated, Literal
 from logger import logger
 
 
@@ -153,6 +153,26 @@ class DPOConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     beta: float = 0.1
 
+class CosineSchedulerConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    start_step: int = 0
+    warmup_steps: int = 20
+    max_steps: int | None = None
+
+class WSDSchedulerConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    start_step: int = 0
+    warmup_steps: int = 20
+    stable_steps: int = 20
+    decay_steps: int | None = None
+    max_steps: int | None = None
+
+class SchedulersConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    active: Literal['cosine', 'wsd'] = 'cosine'
+    cosine: CosineSchedulerConfig = Field(default_factory=CosineSchedulerConfig)
+    wsd: WSDSchedulerConfig = Field(default_factory=WSDSchedulerConfig)
+
 class AdamWConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     min_lr: float = 3e-5
@@ -160,9 +180,7 @@ class AdamWConfig(BaseModel):
     weight_decay: float = 0.1
     betas: tuple[float, float] = (0.9, 0.95)
     use_fused: bool | None = None
-    warmup_steps: int = 20
-    scheduler_start_step: int = 0
-    scheduler_max_steps: int | None = None
+    schedulers: SchedulersConfig = Field(default_factory=SchedulersConfig)
 
 class MuonConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -171,9 +189,7 @@ class MuonConfig(BaseModel):
     max_lr: float = 3e-4
     weight_decay: float = 0.0
     momentum: float = 0.95
-    warmup_steps: int = 20
-    scheduler_start_step: int = 0
-    scheduler_max_steps: int | None = None
+    schedulers: SchedulersConfig = Field(default_factory=SchedulersConfig)
 
 class OptimizersConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/engine/logging.py
+++ b/engine/logging.py
@@ -102,17 +102,19 @@ def prepare_train_step_log(
     muon_metadata = step_metrics.scheduler_metadata.get('muon', None)
 
     adam_lr = adamw_metadata.get('lr', None)
+    adamw_scheduler = adamw_metadata.get('scheduler', None)
     adamw_scheduler_step = adamw_metadata.get('scheduler_step', None)
     adamw_scheduler_max_steps = adamw_metadata.get('scheduler_max_steps', None)
-    scheduler_console_message = f'sched (adamw): step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e}'
+    scheduler_console_message = f'(adamw): ({adamw_scheduler} scheduler) step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e}'
     muon_lr = None
     if muon_metadata and muon_metadata.get('lr', None):
         muon_lr = muon_metadata.get('lr', None)
+        muon_scheduler = muon_metadata.get('scheduler', None)
         muon_scheduler_step = muon_metadata.get('scheduler_step', None)
         muon_scheduler_max_steps = muon_metadata.get('scheduler_max_steps', None)
         scheduler_console_message = (
-            f'(adamw): step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e} | '
-            f'(muon): step {muon_scheduler_step}/{muon_scheduler_max_steps} lr {muon_lr:.4e}'
+            f'(adamw): scheduler ({adamw_scheduler} scheduler) step {adamw_scheduler_step}/{adamw_scheduler_max_steps} lr {adam_lr:.4e} | '
+            f'(muon): scheduler ({muon_scheduler} scheduler) step {muon_scheduler_step}/{muon_scheduler_max_steps} lr {muon_lr:.4e}'
         )
     norm = step_metrics.norm
     dt = step_metrics.dt

--- a/engine/lr_schedulers.py
+++ b/engine/lr_schedulers.py
@@ -1,13 +1,57 @@
 import math
 
 
-def cosine_scheduler(step, min_lr, max_lr, warmup_steps, max_steps):
-    # cosine lr scheduler
+def cosine_decay(decay_ratio, min_lr, max_lr):
+    if decay_ratio < 0 or decay_ratio > 1:
+        raise ValueError(f'Invalid decay_ratio. Must be 0 <= decay_ratio <= 1, got: {decay_ratio}')
+    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
+    return min_lr + coeff * (max_lr - min_lr)
+
+def cosine_scheduler(
+    *,
+    step,
+    min_lr,
+    max_lr,
+    warmup_steps,
+    max_steps
+):
+    if step < 0 or warmup_steps < 0 or max_steps < 0:
+        raise ValueError(f'step, warmup_steps, max_steps must be >= 0')
+    if min_lr > max_lr:
+        raise ValueError(f'min_lr must be <= max_lr, got min_lr={min_lr}, max_lr={max_lr}')
+    if max_steps <= warmup_steps:
+        raise ValueError('max_steps must be > warmup_steps for cosine decay')
+
     if step < warmup_steps:
         return max_lr * (step + 1) / warmup_steps
     if step > max_steps:
         return min_lr
     decay_ratio = (step - warmup_steps) / (max_steps - warmup_steps)
-    assert 0 <= decay_ratio <= 1
-    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
-    return min_lr + coeff * (max_lr - min_lr)
+    return cosine_decay(decay_ratio, min_lr, max_lr)
+
+def wsd_scheduler(
+    *,
+    step,
+    min_lr: float,
+    max_lr: float,
+    warmup_steps: int,
+    stable_steps: int,
+    decay_steps: int
+):
+    # warmup stable decay scheduler
+    if step < 0 or warmup_steps < 0 or stable_steps < 0 or decay_steps < 0:
+        raise ValueError(f'step, warmup_steps, stable_steps, decay_steps must be >= 0')
+    if min_lr > max_lr:
+        raise ValueError(f'min_lr must be <= max_lr, got min_lr={min_lr}, max_lr={max_lr}')
+
+    if warmup_steps + stable_steps + decay_steps <= 0:
+        return max_lr
+    if step < warmup_steps:
+        return max_lr * (step + 1) / warmup_steps
+    if step < warmup_steps + stable_steps:
+        return max_lr
+    decay_step = step - warmup_steps - stable_steps
+    if decay_steps <= 0 or decay_step >= decay_steps:
+        return min_lr
+    decay_ratio = decay_step / decay_steps
+    return cosine_decay(decay_ratio, min_lr, max_lr)

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -65,7 +65,10 @@ from models.adapters.lora import (
 )
 from tasks.factory import get_task
 from engine.wandb import WandbWrapper
-from engine.lr_schedulers import cosine_scheduler
+from engine.lr_schedulers import (
+    cosine_scheduler,
+    wsd_scheduler
+)
 from tqdm.auto import tqdm
 from metrics.memory import (
     reset_memory_usage_metrics,
@@ -771,7 +774,13 @@ class Trainer:
             scaler.unscale_(self.optimizers.muon)
 
     def resolve_scheduler_step(self, current_step, scheduler_start_step):
-        return max(0, current_step - scheduler_start_step)
+        if current_step < scheduler_start_step:
+            raise ValueError(
+                f'Scheduler cannot start in the future: '
+                f'current_step = {current_step}, '
+                f'scheduler_start_step = {scheduler_start_step}'
+            )
+        return current_step - scheduler_start_step
 
     def resolve_scheduler_max_steps(self, max_steps, scheduler_start_step, scheduler_max_steps):
         resolved = scheduler_max_steps if scheduler_max_steps is not None else max_steps - scheduler_start_step
@@ -784,24 +793,89 @@ class Trainer:
             )
         return resolved
 
+    def resolve_scheduler_decay_steps(self, decay_steps, max_steps, warmup_steps, stable_steps):
+        if decay_steps is None:
+            decay_steps = max_steps - warmup_steps - stable_steps
+        if decay_steps < 0:
+            raise ValueError(
+                'Invalid WSD scheduler config: '
+                'warmup_steps + stable_steps must be <= max_steps. '
+                f'warmup_steps = {warmup_steps}, '
+                f'stable_steps = {stable_steps}, '
+                f'max_steps = {max_steps}'
+            )
+        return decay_steps
+
+    def resolve_cosine_scheduler_metadata(self, scheduler_config, step, max_steps, min_lr, max_lr):
+        scheduler_step = self.resolve_scheduler_step(step, scheduler_config.start_step)
+        scheduler_max_steps = self.resolve_scheduler_max_steps(
+            max_steps,
+            scheduler_config.start_step,
+            scheduler_config.max_steps
+        )
+        lr = cosine_scheduler(
+            step=scheduler_step,
+            min_lr=min_lr,
+            max_lr=max_lr,
+            warmup_steps=scheduler_config.warmup_steps,
+            max_steps=scheduler_max_steps
+        )
+        return scheduler_step, scheduler_max_steps, lr
+
+    def resolve_wsd_scheduler_metadata(self, scheduler_config, step, max_steps, min_lr, max_lr):
+        scheduler_step = self.resolve_scheduler_step(step, scheduler_config.start_step)
+        scheduler_max_steps = self.resolve_scheduler_max_steps(
+            max_steps,
+            scheduler_config.start_step,
+            scheduler_config.max_steps
+        )
+        decay_steps = self.resolve_scheduler_decay_steps(
+            scheduler_config.decay_steps,
+            scheduler_max_steps,
+            scheduler_config.warmup_steps,
+            scheduler_config.stable_steps
+        )
+        lr = wsd_scheduler(
+            step=scheduler_step,
+            min_lr=min_lr,
+            max_lr=max_lr,
+            warmup_steps=scheduler_config.warmup_steps,
+            stable_steps=scheduler_config.stable_steps,
+            decay_steps=decay_steps
+        )
+        return scheduler_step, scheduler_max_steps, lr
+
+    def resolve_scheduler_metadata(self, scheduler_config, min_lr, max_lr):
+        if scheduler_config.active == 'cosine':
+            return self.resolve_cosine_scheduler_metadata(
+                scheduler_config.cosine,
+                self.trainer_state.current_step,
+                self.trainer_state.max_steps,
+                min_lr,
+                max_lr
+            )
+        elif scheduler_config.active == 'wsd':
+            return self.resolve_wsd_scheduler_metadata(
+                scheduler_config.wsd,
+                self.trainer_state.current_step,
+                self.trainer_state.max_steps,
+                min_lr,
+                max_lr
+            )
+        else:
+            raise ValueError('Invalid active scheduler')
+
     def update_optimizers_lr(self):
         scheduler_metadata = {}
         if self.optimizers.adamw:
-            adamw_scheduler_step = self.resolve_scheduler_step(
-                self.trainer_state.current_step,
-                self.config.optimizers.adamw.scheduler_start_step
-            )
-            adamw_scheduler_max_steps = self.resolve_scheduler_max_steps(
-                self.trainer_state.max_steps,
-                self.config.optimizers.adamw.scheduler_start_step,
-                self.config.optimizers.adamw.scheduler_max_steps
-            )
-            adamw_lr = cosine_scheduler(
-                step=adamw_scheduler_step,
-                warmup_steps=self.config.optimizers.adamw.warmup_steps,
-                max_steps=adamw_scheduler_max_steps,
-                max_lr=self.config.optimizers.adamw.max_lr,
-                min_lr=self.config.optimizers.adamw.min_lr,
+            (
+                adamw_scheduler_step,
+                adamw_scheduler_max_steps,
+                adamw_lr
+            ) = self.resolve_scheduler_metadata(
+                self.config.optimizers.adamw.schedulers,
+                self.config.optimizers.adamw.min_lr,
+                self.config.optimizers.adamw.max_lr
             )
             for group in self.optimizers.adamw.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)
@@ -812,21 +886,14 @@ class Trainer:
                 'scheduler_max_steps': adamw_scheduler_max_steps
             }
         if self.optimizers.muon:
-            muon_scheduler_step = self.resolve_scheduler_step(
-                self.trainer_state.current_step,
-                self.config.optimizers.muon.scheduler_start_step
-            )
-            muon_scheduler_max_steps = self.resolve_scheduler_max_steps(
-                self.trainer_state.max_steps,
-                self.config.optimizers.muon.scheduler_start_step,
-                self.config.optimizers.muon.scheduler_max_steps
-            )
-            muon_lr = cosine_scheduler(
-                step=muon_scheduler_step,
-                warmup_steps=self.config.optimizers.muon.warmup_steps,
-                max_steps=muon_scheduler_max_steps,
-                max_lr=self.config.optimizers.muon.max_lr,
-                min_lr=self.config.optimizers.muon.min_lr,
+            (
+                muon_scheduler_step,
+                muon_scheduler_max_steps,
+                muon_lr
+            ) = self.resolve_scheduler_metadata(
+                self.config.optimizers.muon.schedulers,
+                self.config.optimizers.muon.min_lr,
+                self.config.optimizers.muon.max_lr
             )
             for group in self.optimizers.muon.param_groups:
                 lr_scale = group.get('lr_scale', 1.0)

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -804,6 +804,15 @@ class Trainer:
                 f'stable_steps = {stable_steps}, '
                 f'max_steps = {max_steps}'
             )
+        if warmup_steps + stable_steps + decay_steps > max_steps:
+            raise ValueError(
+                'Invalid WSD scheduler config: '
+                'warmup_steps + stable_steps + decay_steps must be <= max_steps. '
+                f'warmup_steps = {warmup_steps}, '
+                f'stable_steps = {stable_steps}, '
+                f'decay_steps = {decay_steps}, '
+                f'max_steps = {max_steps}'
+            )
         return decay_steps
 
     def resolve_cosine_scheduler_metadata(self, scheduler_config, step, max_steps, min_lr, max_lr):
@@ -882,6 +891,7 @@ class Trainer:
                 group['lr'] = adamw_lr * lr_scale
             scheduler_metadata['adamw'] = {
                 'lr': adamw_lr,
+                'scheduler': self.config.optimizers.adamw.schedulers.active,
                 'scheduler_step': adamw_scheduler_step,
                 'scheduler_max_steps': adamw_scheduler_max_steps
             }
@@ -900,6 +910,7 @@ class Trainer:
                 group['lr'] = muon_lr * lr_scale
             scheduler_metadata['muon'] = {
                 'lr': muon_lr,
+                'scheduler': self.config.optimizers.muon.schedulers.active,
                 'scheduler_step': muon_scheduler_step,
                 'scheduler_max_steps': muon_scheduler_max_steps
             }

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -55,7 +55,10 @@ config:
       weight_decay: 0.1
       betas: [0.9, 0.95]
       use_fused: null
-      warmup_steps: 2
+      schedulers:
+        active: cosine
+        cosine:
+          warmup_steps: 2
     muon:
       enabled: false
 

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -55,7 +55,10 @@ config:
       weight_decay: 0.1
       betas: [0.9, 0.95]
       use_fused: null
-      warmup_steps: 2
+      schedulers:
+        active: cosine
+        cosine:
+          warmup_steps: 2
     muon:
       enabled: false
 

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -16,7 +16,7 @@ config:
     stage: pretraining
     seed: 42
     total_batch_size: 32768
-    max_steps: 10
+    max_steps: 20
     early_stopping_patience: 5
     early_stopping_patience_skip_steps: 0
 
@@ -56,7 +56,10 @@ config:
       weight_decay: 0.1
       betas: [0.9, 0.95]
       use_fused: null
-      warmup_steps: 2
+      schedulers:
+        active: cosine
+        cosine:
+          warmup_steps: 2
     muon:
       enabled: false
 

--- a/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
+++ b/recipes/pretraining/tendril/870m_1xh100_smoke.yaml
@@ -56,7 +56,10 @@ config:
       weight_decay: 0.1
       betas: [0.9, 0.95]
       use_fused: null
-      warmup_steps: 2
+      schedulers:
+        active: cosine
+        cosine:
+          warmup_steps: 2
     muon:
       enabled: false
 

--- a/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
+++ b/recipes/pretraining/tendril/870m_8xh100_17b_tokens.yaml
@@ -56,7 +56,10 @@ config:
       weight_decay: 0.1
       betas: [0.9, 0.95]
       use_fused: null
-      warmup_steps: 500
+      schedulers:
+        active: cosine
+        cosine:
+          warmup_steps: 500
     muon:
       enabled: false
 


### PR DESCRIPTION
This PR adds support for WSD scheduler.

Changes:
- Added support for WSD scheduler (also small cleanup in cosine scheduler);
- Optimizers config modified to support `schedulers` where each config can be added. Note: only one can be active. (cosine by default)
- Updated recipes for compatibility;