### PR TITLE
Control interleave stopping strategy; Raise if token target not met

### DIFF
--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -57,6 +57,7 @@ def assert_common_structure_and_extract(datasets_mix, supported_datasets):
     if 'validation_ratio' in common_settings:
         validation_ratio = common_settings['validation_ratio']
         assert validation_ratio is None or isinstance(validation_ratio, float), 'datasets_common_settings.validation_ratio must be a float'
+    assert 'interleave_stopping_strategy' in common_settings, 'common_settings.interleave_stopping_strategy is required'
 
     assert 'datasets' in datasets_mix
     datasets = datasets_mix['datasets']

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -525,6 +525,15 @@ def shard_and_tokenize(
             pool.close()
         pool.join()
 
+    if target_tokens is not None and not reached_target():
+        state.status = 'exhausted_before_target'
+        save_state(state)
+        raise RuntimeError(
+            'Pretraining dataset exhausted before reaching target tokens. '
+            f'train_tokens={train_writer.total_tokens:,}/{target_tokens:,}, '
+            f'val_tokens={val_writer.total_tokens:,}/{val_target_tokens:,}'
+        )
+
     train_writer.finish()
     val_writer.finish()
 

--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -106,7 +106,8 @@ def download_and_prepare_data(
     valid_datasets,
     probabilities,
     num_proc,
-    validation_ratio
+    validation_ratio,
+    interleave_stopping_strategy
 ):
     tokenizer_kwargs = {
         'path': config.tokenizer.checkpoint_path,
@@ -171,7 +172,8 @@ def download_and_prepare_data(
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,
-            seed=seed
+            seed=seed,
+            stopping_strategy=interleave_stopping_strategy
         )
         time.sleep(2) # Workaround for occasional streaming/interleave iterator shutdown issue.
         logger.info('Interleaving datasets complete')
@@ -216,5 +218,6 @@ def prepare_dpo_dataset(
         valid_datasets=valid_datasets,
         probabilities=probabilities,
         num_proc=num_proc,
-        validation_ratio=validation_ratio
+        validation_ratio=validation_ratio,
+        interleave_stopping_strategy=common_settings['interleave_stopping_strategy']
     )

--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -168,7 +168,7 @@ def download_and_prepare_data(
         prepared_datasets.append(tokenized_ds)
 
     if len(prepared_datasets) > 1:
-        logger.info('Preparing Interleaving iterator... This operation can take a few minutes...')
+        logger.info(f'Preparing Interleaving iterator... This operation can take a few minutes... Using strategy: {interleave_stopping_strategy}')
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -224,7 +224,7 @@ def download_and_prepare_data(
         prepared_datasets.append(tokenized_ds)
 
     if len(prepared_datasets) > 1:
-        logger.info('Preparing Interleaving iterator... This operation can take a few minutes...')
+        logger.info(f'Preparing Interleaving iterator... This operation can take a few minutes... Using strategy: {interleave_stopping_strategy}')
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -152,7 +152,8 @@ def download_and_prepare_data(
     valid_datasets,
     probabilities,
     num_proc,
-    validation_ratio
+    validation_ratio,
+    interleave_stopping_strategy
 ):
     tokenizer_kwargs = {
         'path': config.tokenizer.checkpoint_path,
@@ -227,7 +228,8 @@ def download_and_prepare_data(
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,
-            seed=seed
+            seed=seed,
+            stopping_strategy=interleave_stopping_strategy
         )
         time.sleep(2) # Workaround for occasional streaming/interleave iterator shutdown issue.
         logger.info('Interleaving datasets complete')
@@ -271,5 +273,6 @@ def prepare_instruct_dataset(
         valid_datasets=valid_datasets,
         probabilities=probabilities,
         num_proc=num_proc,
-        validation_ratio=validation_ratio
+        validation_ratio=validation_ratio,
+        interleave_stopping_strategy=common_settings['interleave_stopping_strategy']
     )

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -186,7 +186,7 @@ def download_and_prepare_data(
         prepared_datasets.append(ds)
 
     if len(prepared_datasets) > 1:
-        logger.info('Preparing Interleaving iterator... This operation can take a few minutes...')
+        logger.info(f'Preparing Interleaving iterator... This operation can take a few minutes... Using strategy: {interleave_stopping_strategy}')
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -189,7 +189,8 @@ def download_and_prepare_data(
         prepared_dataset = interleave_datasets(
             prepared_datasets,
             probabilities=probabilities,
-            seed=seed
+            seed=seed,
+            stopping_strategy='all_exhausted'
         )
         time.sleep(2) # Workaround for occasional streaming/interleave iterator shutdown issue.
         logger.info('Interleaving datasets complete')

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -127,7 +127,8 @@ def download_and_prepare_data(
     config,
     seed,
     valid_datasets,
-    probabilities
+    probabilities,
+    interleave_stopping_strategy
 ):
     prepared_datasets = []
     for dataset in valid_datasets:
@@ -190,7 +191,7 @@ def download_and_prepare_data(
             prepared_datasets,
             probabilities=probabilities,
             seed=seed,
-            stopping_strategy='all_exhausted'
+            stopping_strategy=interleave_stopping_strategy
         )
         time.sleep(2) # Workaround for occasional streaming/interleave iterator shutdown issue.
         logger.info('Interleaving datasets complete')
@@ -236,7 +237,8 @@ def prepare_pretraining_dataset(
         config=config,
         seed=seed,
         valid_datasets=valid_datasets,
-        probabilities=probabilities
+        probabilities=probabilities,
+        interleave_stopping_strategy=common_settings['interleave_stopping_strategy']
     )
 
     tokenizer_kwargs = {

--- a/recipes/config.py
+++ b/recipes/config.py
@@ -2,7 +2,7 @@ import yaml
 
 from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field
-from typing import Any
+from typing import Any, Literal
 from config import GlobalConfig
 from logger import logger
 
@@ -12,6 +12,7 @@ class DatasetsCommonSettings(BaseModel):
     shard_size: int | None = None
     target_tokens: int | None = None
     validation_ratio: float = 0.01
+    interleave_stopping_strategy: Literal['first_exhausted', 'all_exhausted', 'all_exhausted_without_replacement'] = 'first_exhausted'
 
 class DatasetEntryConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')


### PR DESCRIPTION
Changes:
- interleave stopping strategy is now configurable;
- if target tokens is set and it is not met, raise error and finish with special status: `exhausted_before_target`