### PR TITLE
flag to reset dataloaders state

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ HF_HOME='./cache'
   --dpo                             # Automatically sets DPO stage.
   --checkpoint <file>               # Resume training from a specific checkpoint
   --reset-optimizers                # Ignore stored optimizer(s) state
-  --reset-dataloaders               # Ignore stored optimizer(s) state
+  --reset-dataloaders               # Ignore stored dataloaders state
   --start-step <N>                  # Override internal step counter
 ```
 **NOTES:**

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ HF_HOME='./cache'
   --dpo                             # Automatically sets DPO stage.
   --checkpoint <file>               # Resume training from a specific checkpoint
   --reset-optimizers                # Ignore stored optimizer(s) state
+  --reset-dataloaders               # Ignore stored optimizer(s) state
   --start-step <N>                  # Override internal step counter
 ```
 **NOTES:**

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -481,7 +481,10 @@ class Trainer:
         if args.reset_optimizers:
             logger.warning('Reset optimizers flag was set')
 
-        if ddp_world_size_changed or training_stage_changed:
+        if args.reset_dataloaders:
+            logger.warning('Reset dataloaders flag was set')
+
+        if ddp_world_size_changed or training_stage_changed or args.reset_dataloaders:
             if checkpoint_data.train_loader_state is not None and checkpoint_data.val_loader_state is not None:
                 logger.warning('ignoring stored metadata for dataloaders...')
                 checkpoint_data.train_loader_state = None

--- a/train.py
+++ b/train.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     checkpoint_group.add_argument('--checkpoint', type=str, default=None, help='Checkpoint file path to load.')
 
     parser.add_argument('--reset-optimizers', action='store_true', help='Reset the optimizers state when loading a checkpoint.')
+    parser.add_argument('--reset-dataloaders', action='store_true', help='Reset the dataloaders state when loading a checkpoint.')
     parser.add_argument('--start-step', type=int, default=None, help='Starting step number for training.')
 
     args = parser.parse_args()


### PR DESCRIPTION
Added `--reset-dataloaders` flag to force reset state when loading from a checkpoint if necessary.