### PR TITLE
cleaner defaults for generation

### DIFF
--- a/cli/common.py
+++ b/cli/common.py
@@ -53,9 +53,9 @@ def validate_generation_args(args: argparse.Namespace, parser: argparse.Argument
         parser.error('--top-p must be in (0, 1].')
     if args.max_gen_len <= 0:
         parser.error('--max-gen-len must be > 0.')
-    if args.repetition_penalty and args.repetition_penalty <= 1.0:
+    if args.repetition_penalty is not None and args.repetition_penalty <= 1.0:
         parser.error('--repetition-penalty must be > 1.0')
-    if args.no_repeat_ngram_size and args.no_repeat_ngram_size <= 1:
+    if args.no_repeat_ngram_size is not None and args.no_repeat_ngram_size <= 1:
         parser.error('--no-repeat-ngram-size must be >= 2')
 
 def add_runtime_args(parser: argparse.ArgumentParser):

--- a/cli/common.py
+++ b/cli/common.py
@@ -36,27 +36,27 @@ def add_generation_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         '--repetition-penalty',
         type=float,
-        default=1.0,
-        help='Penalty for already generated tokens. 1.0 means disabled. Common values: ~1.05 to ~1.2.',
+        default=None,
+        help='Penalty for already generated tokens. Must be > 1.0. Common values: ~1.05 to ~1.2.',
     )
     parser.add_argument(
         '--no-repeat-ngram-size',
         type=int,
-        default=1,
-        help='Block repeated ngrams of this size. 1 means disabled. Common values: ~3 to ~5.',
+        default=None,
+        help='Block repeated ngrams of this size. Must be > 2. Common values: ~3 to ~5.',
     )
 
 def validate_generation_args(args: argparse.Namespace, parser: argparse.ArgumentParser):
     if args.temperature < 0:
-        parser.error('--temperature must be >= 0.')
+        parser.error('--temperature must be >= 0.0.')
     if not (0.0 < args.top_p <= 1.0):
-        parser.error('--top-p must be between 0.0 and 1.0.')
+        parser.error('--top-p must be in (0, 1].')
     if args.max_gen_len <= 0:
         parser.error('--max-gen-len must be > 0.')
-    if args.repetition_penalty <= 0:
-        parser.error('--repetition-penalty must be > 0')
-    if args.no_repeat_ngram_size < 1:
-        parser.error('--no-repeat-ngram-size must be >= 1')
+    if args.repetition_penalty and args.repetition_penalty <= 1.0:
+        parser.error('--repetition-penalty must be > 1.0')
+    if args.no_repeat_ngram_size and args.no_repeat_ngram_size <= 1:
+        parser.error('--no-repeat-ngram-size must be >= 2')
 
 def add_runtime_args(parser: argparse.ArgumentParser):
     parser.add_argument(

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1225,13 +1225,16 @@ class Trainer:
                 model=get_model(self.model),
                 tokenizer=self.tokenizer,
                 max_gen_len=self.config.generation.max_test_gen_len,
+                temperature=0.0,
+                top_p=1.0,
+                repetition_penalty=None,
+                no_repeat_ngram_size=None,
                 full_seq=True,
                 device=self.trainer_ctx.device.device,
                 dtype=self.trainer_ctx.precision.autocast_dtype,
                 is_instruct=self.is_instruct(),
-                temperature=0.0,
-                top_p=1.0,
-                use_kv_cache=True
+                use_kv_cache=True,
+                batch_size=self.config.model.max_batch_size
             )
 
         if not self.trainer_ctx.distributed.is_master_process:

--- a/inference/checkpoint_inspector.py
+++ b/inference/checkpoint_inspector.py
@@ -33,15 +33,16 @@ class CheckpointInspector:
         self,
         prompts,
         *,
-        max_gen_len=256,
+        max_gen_len=128,
         temperature=0.0,
         top_p=1.0,
-        repetition_penalty=1.0,
-        no_repeat_ngram_size=1,
+        repetition_penalty=None,
+        no_repeat_ngram_size=None,
         full_seq=False,
         instruct=False,
-        use_kv_cache=True,
-        batch_size=2,
+        use_kv_cache=False,
+        batch_size=1,
+        skip_encoding=False,
         print_text=True
     ):
         with torch.autocast(
@@ -63,7 +64,8 @@ class CheckpointInspector:
                 dtype=self.dtype,
                 is_instruct=instruct,
                 use_kv_cache=use_kv_cache,
-                batch_size=batch_size
+                batch_size=batch_size,
+                skip_encoding=skip_encoding
             )
 
         results = [

--- a/inference/generation.py
+++ b/inference/generation.py
@@ -35,7 +35,7 @@ def apply_repetition_penalty(current_tokens, logits, penalty):
     ''' Applies the repetition penalty to reduce the probability of the same exact tokens appear multiple times even if they have strong logit.
         Modification is in-place.
     '''
-    if penalty == 1.0:
+    if penalty is None:
         return
 
     # (for each batch index) look at all the token logits that already were generated and apply the penalty:
@@ -55,7 +55,7 @@ def apply_no_repeat_ngram(current_tokens, logits, ngram_size):
     tokens "ngram_size" for the prefix "ngram_size - 1" (Tokens that would complete an ngram).
         Modification is in-place.
     '''
-    if ngram_size <= 1 or current_tokens.size(1) < ngram_size - 1:
+    if ngram_size is None or current_tokens.size(1) < ngram_size - 1:
         return
 
     for batch_index in range(logits.size(0)):
@@ -127,12 +127,20 @@ def generate(
     repetition_penalty,
     no_repeat_ngram_size,
     device,
-    dtype=torch.float32,
-    use_kv_cache=False
+    dtype,
+    use_kv_cache
 ):
+    if temperature < 0.0:
+        raise ValueError(f'temperature must be >= 0.0, got {temperature}')
+    if top_p <= 0.0 or top_p > 1.0:
+        raise ValueError(f'top_p must be in (0, 1], got {top_p}')
+    if repetition_penalty is not None and repetition_penalty <= 1.0:
+        raise ValueError(f'repetition_penalty must be null or > 1.0, got {repetition_penalty}') 
+    if no_repeat_ngram_size is not None and no_repeat_ngram_size <= 1:
+        raise ValueError(f'no_repeat_ngram_size must be null or >= 2, got {no_repeat_ngram_size}')
+
     batch_size = len(prompt_tokens)
 
-    vocab_size = tokenizer.vocab_size
     pad_token_id = tokenizer.pad_id
     stop_tokens = tokenizer.stop_tokens
     eos_id = tokenizer.eos_id
@@ -232,18 +240,18 @@ def generate_and_decode(
         prompts,
         model,
         tokenizer,
-        max_gen_len=256,
-        temperature=0.6,
-        top_p=0.9,
-        repetition_penalty=1.0,
-        no_repeat_ngram_size=1,
-        full_seq=False,
-        device='cpu',
-        dtype=torch.float32,
-        is_instruct=False,
-        skip_encoding=False,
-        use_kv_cache=False,
-        batch_size=None
+        max_gen_len,
+        temperature,
+        top_p,
+        repetition_penalty,
+        no_repeat_ngram_size,
+        full_seq,
+        device,
+        dtype,
+        is_instruct,
+        use_kv_cache,
+        batch_size,
+        skip_encoding=False
     ):
         vocab_size = tokenizer.vocab_size
         pad_token_id = tokenizer.pad_id

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,10 +20,11 @@ def test_generate_kv_cache_matches_no_cache_greedy(model, tokenizer, device):
         prompt_tokens=prompts,
         max_gen_len=16,
         temperature=0.0,
-        top_p=0.9, # ignored when temperature=0
-        repetition_penalty=1.0,
-        no_repeat_ngram_size=1,
-        device=device
+        top_p=1.0,
+        repetition_penalty=None,
+        no_repeat_ngram_size=None,
+        device=device,
+        dtype=torch.float32
     )
 
     out_no_cache = generate(**kwargs, use_kv_cache=False)
@@ -49,10 +50,11 @@ def test_generate_batched_variable_lengths_smoke(model, tokenizer, device):
         prompt_tokens=prompts,
         max_gen_len=max_gen_len,
         temperature=0.0,
-        top_p=0.9,
-        repetition_penalty=1.0,
-        no_repeat_ngram_size=1,
+        top_p=1.0,
+        repetition_penalty=None,
+        no_repeat_ngram_size=None,
         device=device,
+        dtype=torch.float32,
         use_kv_cache=True,
     )
 
@@ -73,11 +75,12 @@ def test_generate_empty_prompt_raises(model, tokenizer, device):
                 prompt_tokens=[[1, 2, 3], []], # one empty prompt
                 max_gen_len=8,
                 temperature=0.0,
-                top_p=0.9,
-                repetition_penalty=1.0,
-                no_repeat_ngram_size=1,
+                top_p=1.0,
+                repetition_penalty=None,
+                no_repeat_ngram_size=None,
                 device=device,
-                use_kv_cache=True,
+                dtype=torch.float32,
+                use_kv_cache=True
             )
             assert False, 'Expected ValueError for empty prompt'
         except ValueError as e:


### PR DESCRIPTION
Supporting null to disable `repetition_penalty` or `no_repeat_ngram_size` is cleaner.

Removed some defaults so config is more explicit.