### PR TITLE
Refactor micro batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ HF_HOME='./cache'
   --reset-optimizers                # Ignore stored optimizer(s) state
   --reset-dataloaders               # Ignore stored dataloaders state
   --start-step <N>                  # Override internal step counter
+  --micro-batch-size <N>            # Override config.training.micro_batch_size
 ```
 **NOTES:**
   - The project output path can be configured in `config.py` under `GlobalConfig.paths.runs`. By default it will use `./runs`

--- a/config.py
+++ b/config.py
@@ -69,7 +69,6 @@ class ModelConfig(BaseModel):
     ffn_dim_multiplier: float = 1.0
     norm_eps: float = 1e-5
     rope_theta: float = 500000.0
-    max_batch_size: int = 4
     max_seq_len: int = 1024
     moe: MoEConfig | None = None
 
@@ -82,6 +81,7 @@ class TrainingConfig(BaseModel):
     stage: TrainingStage = TrainingStage.PRETRAINING
     seed: int = 42
     total_batch_size: int = 524288
+    micro_batch_size: int = 4
     max_steps: int = 200
     early_stopping_patience: int = 100
     early_stopping_patience_skip_steps: int = 0

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -295,18 +295,19 @@ class Trainer:
             raise ValueError('Invalid training precision')
 
     def compute_grad_accum_steps(self, ddp_world_size):
+        micro_batch_size = self.config.training.micro_batch_size
         #### BATCH SIZE CHECKS (For now assumes token based autoregressive training...)
-        # NOTE: total_batch_size is the total batch size in tokens. The model max_batch_size is the number of sequences per device during forward pass (micro batches).
-        # The total batch size must be a multiple of (max_batch_size * max_seq_len * ddp_world_size). This is needed for the gradient accumulation steps to be calculated correctly.
-        if self.config.training.total_batch_size % (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size) != 0:
-            raise ValueError('total_batch_size must be divisible by (max_batch_size * max_seq_len * ddp_world_size)')
+        # NOTE: total_batch_size is the total batch size in tokens. The micro_batch_size is the number of sequences per device during forward pass (micro batches).
+        # The total batch size must be a multiple of (micro_batch_size * max_seq_len * ddp_world_size). This is needed for the gradient accumulation steps to be calculated correctly.
+        if self.config.training.total_batch_size % (micro_batch_size * self.config.model.max_seq_len * ddp_world_size) != 0:
+            raise ValueError('total_batch_size must be divisible by (micro_batch_size * max_seq_len * ddp_world_size)')
 
         # Gradient accumulation steps
-        grad_accum_steps = self.config.training.total_batch_size // (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size)
+        grad_accum_steps = self.config.training.total_batch_size // (micro_batch_size * self.config.model.max_seq_len * ddp_world_size)
 
         # Final check to validate previous calculations.
-        if self.config.training.total_batch_size != (self.config.model.max_batch_size * self.config.model.max_seq_len * ddp_world_size * grad_accum_steps):
-            raise ValueError('total batch size MUST EQUAL (max_batch_size * max_seq_len * ddp_world_size * grad_accum_steps)')
+        if self.config.training.total_batch_size != (micro_batch_size * self.config.model.max_seq_len * ddp_world_size * grad_accum_steps):
+            raise ValueError('total batch size MUST EQUAL (micro_batch_size * max_seq_len * ddp_world_size * grad_accum_steps)')
 
         return grad_accum_steps
 
@@ -425,7 +426,7 @@ class Trainer:
 
     def build_data_loaders(self):
         self.train_loader, self.val_loader = init_data_loaders(
-            batch_size=self.config.model.max_batch_size,
+            batch_size=self.config.training.micro_batch_size,
             sequence_length=self.config.model.max_seq_len,
             is_master_process=self.distributed_ctx.is_master_process,
             ddp_rank=self.distributed_ctx.ddp_rank,
@@ -1234,7 +1235,7 @@ class Trainer:
                 dtype=self.trainer_ctx.precision.autocast_dtype,
                 is_instruct=self.is_instruct(),
                 use_kv_cache=True,
-                batch_size=self.config.model.max_batch_size
+                batch_size=self.config.training.micro_batch_size
             )
 
         if not self.trainer_ctx.distributed.is_master_process:

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -132,6 +132,7 @@ class Trainer:
 
     def setup(self):
         self.set_seed()
+        self.resolve_config_overrides()
         self.setup_global_torch_optimizations()
         self.build_contexts()
         self.setup_local_logging()
@@ -156,6 +157,21 @@ class Trainer:
 
     def set_seed(self):
         set_seed(self.config.training.seed)
+
+    def resolve_config_overrides(self):
+        override_messages = []
+        if self.args.micro_batch_size is not None:
+            override_messages.append(
+                f'Overriding config.training.micro_batch_size "{self.config.training.micro_batch_size}" '
+                f'with "{self.args.micro_batch_size}".'
+            )
+            self.config.training.micro_batch_size = self.args.micro_batch_size
+
+        if override_messages:
+            logger.section('Config overrides', force=True)
+            for message in override_messages:
+                logger.warning(message, force=True)
+            logger.info('\n', force=True)
 
     def setup_global_torch_optimizations(self):
         torch.backends.cuda.matmul.fp32_precision = 'tf32'

--- a/evaluate.py
+++ b/evaluate.py
@@ -73,9 +73,6 @@ if __name__ == '__main__':
 
     checkpoint_data = load_checkpoint_for_inference(args.checkpoint)
 
-    if args.batch_size > checkpoint_data.config.model.max_batch_size:
-        parser.error(f'--batch-size ({args.batch_size}) cannot exceed model.max_batch_size ({checkpoint_data.config.model.max_batch_size})')
-
     set_seed(args.seed)
 
     output_path, name, timestamp = build_output_path_for_run(

--- a/generate.py
+++ b/generate.py
@@ -44,9 +44,6 @@ if __name__ == '__main__':
     checkpoint_data = load_checkpoint_for_inference(args.checkpoint)
     prompts = validate_input_prompts_list(load_json_file(args.prompts), parser)
 
-    if args.batch_size > checkpoint_data.config.model.max_batch_size:
-        parser.error(f'--batch-size ({args.batch_size}) cannot exceed model.max_batch_size ({checkpoint_data.config.model.max_batch_size})')
-
     set_seed(args.seed)
 
     output_path, name, timestamp = build_output_path_for_run(

--- a/recipes/dpo/debug.yaml
+++ b/recipes/dpo/debug.yaml
@@ -16,6 +16,7 @@ config:
     stage: dpo
     seed: 42
     total_batch_size: 8192
+    micro_batch_size: 2
     max_steps: 10
     early_stopping_patience: 100
     early_stopping_patience_skip_steps: 0
@@ -30,7 +31,6 @@ config:
     ffn_dim_multiplier: 1.0
     norm_eps: 1.0e-5
     rope_theta: 500000.0
-    max_batch_size: 2
     max_seq_len: 512
 
   prompts:

--- a/recipes/instruct/debug.yaml
+++ b/recipes/instruct/debug.yaml
@@ -16,6 +16,7 @@ config:
     stage: instruct
     seed: 42
     total_batch_size: 8192
+    micro_batch_size: 2
     max_steps: 10
     early_stopping_patience: 100
     early_stopping_patience_skip_steps: 0
@@ -30,7 +31,6 @@ config:
     ffn_dim_multiplier: 1.0
     norm_eps: 1.0e-5
     rope_theta: 500000.0
-    max_batch_size: 2
     max_seq_len: 512
 
   prompts:

--- a/recipes/pretraining/debug.yaml
+++ b/recipes/pretraining/debug.yaml
@@ -16,6 +16,7 @@ config:
     stage: pretraining
     seed: 42
     total_batch_size: 32768
+    micro_batch_size: 2
     max_steps: 20
     early_stopping_patience: 5
     early_stopping_patience_skip_steps: 0
@@ -30,7 +31,6 @@ config:
     ffn_dim_multiplier: 1.0
     norm_eps: 1.0e-5
     rope_theta: 500000.0
-    max_batch_size: 4
     max_seq_len: 1024
 
   tokenizer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def model(device, tokenizer):
         ffn_dim_multiplier=1.0,
         norm_eps=1e-05,
         rope_theta=500000.0,
-        max_batch_size=2,
         max_seq_len=32
     )
 

--- a/train.py
+++ b/train.py
@@ -23,11 +23,15 @@ if __name__ == '__main__':
     parser.add_argument('--reset-optimizers', action='store_true', help='Reset the optimizers state when loading a checkpoint.')
     parser.add_argument('--reset-dataloaders', action='store_true', help='Reset the dataloaders state when loading a checkpoint.')
     parser.add_argument('--start-step', type=int, default=None, help='Starting step number for training.')
+    parser.add_argument('--micro-batch-size', type=int, default=None, help='Overrides the micro-batch-size set in config.training.micro_batch_size')
 
     args = parser.parse_args()
 
     if args.recipe and (args.pretraining or args.instruct or args.dpo):
         parser.error('--recipe defines the training stage. Cannot combine --recipe with --pretraining, --instruct, or --dpo.')
+
+    if args.micro_batch_size is not None and args.micro_batch_size <= 0:
+        parser.error('--micro-batch-size must be >= 1')
 
     if args.recipe:
         cfg = load_recipe(args.recipe).config


### PR DESCRIPTION
Removed `max_batch_size` from the model config as it does not make sense. Instead it is not `training.micro_batch_size`.
Added new flag `--micro-batch-size` override to train.py. This is helpful to override the config/recipe value when testing devices.

NOTE: This breaks checkpoints, needs migration which is not provided here.