### PR TITLE
Can load and use hf checkpoints directly

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,10 +57,12 @@ class MoEConfig(BaseModel):
 class ModelArchitecture(str, Enum):
     TENDRIL = 'tendril'
     TENDRIL_MOE = 'tendril_moe'
+    HF_WRAPPER = 'hf_wrapper'
 
 class ModelConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     architecture: ModelArchitecture = ModelArchitecture.TENDRIL
+    model_name: str | None = None
     dim: int = 768
     n_layers: int = 16
     n_heads: int = 16

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -1,0 +1,47 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM
+from models.base import BaseModel
+from config import ModelConfig
+
+
+class HFModelWrapper(BaseModel):
+    def __init__(self, *, config: ModelConfig, pad_token_id: int, vocab_size: int, ignore_index: int):
+        super().__init__(
+            config=config,
+            pad_token_id=pad_token_id,
+            vocab_size=vocab_size,
+            ignore_index=ignore_index,
+        )
+
+        if config.model_name is None:
+            raise ValueError('Cannot use hf_wrapper architecture without providing a model path to load.')
+
+        self.inner = AutoModelForCausalLM.from_pretrained(config.model_name)
+        self.inner.resize_token_embeddings(vocab_size)
+
+        self.config = self.inner.config
+        self.config.max_seq_len = self.inner.config.max_position_embeddings
+        self.config.n_layers = self.inner.config.num_hidden_layers
+        self.config.n_heads  = self.inner.config.num_attention_heads
+        self.config.dim      = self.inner.config.hidden_size
+        self.config.n_kv_heads = self.inner.config.num_key_value_heads
+        self.pad_token_id = self.inner.config.pad_token_id
+        self.vocab_size = self.inner.config.vocab_size
+
+    @classmethod
+    def validate_config(cls, config: ModelConfig):
+        pass
+
+    def get_input_embeddings(self):
+        return self.inner.get_input_embeddings()
+
+    def get_output_embeddings(self):
+        return self.inner.get_output_embeddings()
+
+    def forward(self, input_ids, labels=None, **kwargs):
+        out = self.inner(input_ids=input_ids, labels=labels)
+        return {
+            'logits': out.logits,
+            'loss': out.loss,
+        }

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -1,12 +1,18 @@
-import torch
-import torch.nn as nn
 from transformers import AutoModelForCausalLM
-from models.base import BaseModel
 from config import ModelConfig
+from models.base import BaseModel
+from logger import logger
 
 
 class HFModelWrapper(BaseModel):
-    def __init__(self, *, config: ModelConfig, pad_token_id: int, vocab_size: int, ignore_index: int):
+    def __init__(
+        self,
+        *,
+        config: ModelConfig,
+        pad_token_id: int,
+        vocab_size: int,
+        ignore_index: int,
+    ):
         super().__init__(
             config=config,
             pad_token_id=pad_token_id,
@@ -14,24 +20,32 @@ class HFModelWrapper(BaseModel):
             ignore_index=ignore_index,
         )
 
-        if config.model_name is None:
-            raise ValueError('Cannot use hf_wrapper architecture without providing a model path to load.')
-
         self.inner = AutoModelForCausalLM.from_pretrained(config.model_name)
-        self.inner.resize_token_embeddings(vocab_size)
 
-        self.config = self.inner.config
-        self.config.max_seq_len = self.inner.config.max_position_embeddings
-        self.config.n_layers = self.inner.config.num_hidden_layers
-        self.config.n_heads = self.inner.config.num_attention_heads
-        self.config.dim = self.inner.config.hidden_size
-        self.config.n_kv_heads = self.inner.config.num_key_value_heads
-        self.pad_token_id = self.inner.config.pad_token_id
-        self.vocab_size = self.inner.config.vocab_size
+        if self.inner.config.vocab_size != vocab_size:
+            logger.warning(
+                f'Tokenizer vocab_size={vocab_size} does not match HF model '
+                f'vocab_size={self.inner.config.vocab_size}. It is recommended to use the matching tokenizer. '
+                'Automatically resizing for compatibility... '
+            )
+            self.inner.resize_token_embeddings(vocab_size)
+
+        self.hf_config = self.inner.config
+
+        self.hf_config.pad_token_id = pad_token_id
+        if getattr(self.inner, 'generation_config', None) is not None:
+            self.inner.generation_config.pad_token_id = pad_token_id
+
+        self.max_seq_len = getattr(self.hf_config, 'max_position_embeddings', config.max_seq_len)
+        self.n_layers = getattr(self.hf_config, 'num_hidden_layers', None)
+        self.n_heads = getattr(self.hf_config, 'num_attention_heads', None)
+        self.dim = getattr(self.hf_config, 'hidden_size', None)
+        self.n_kv_heads = getattr(self.hf_config, 'num_key_value_heads', self.n_heads)
 
     @classmethod
     def validate_config(cls, config: ModelConfig):
-        pass
+        if config.model_name is None:
+            raise ValueError('Cannot use hf_wrapper architecture without model.model_name.')
 
     def get_input_embeddings(self):
         return self.inner.get_input_embeddings()
@@ -40,7 +54,10 @@ class HFModelWrapper(BaseModel):
         return self.inner.get_output_embeddings()
 
     def forward(self, input_ids, labels=None, **kwargs):
-        out = self.inner(input_ids=input_ids, labels=labels)
+        if 'attention_mask' not in kwargs:
+            attention_mask = (input_ids != self.pad_token_id).long()
+            kwargs['attention_mask'] = attention_mask
+        out = self.inner(input_ids=input_ids, labels=labels, **kwargs)
         return {
             'logits': out.logits,
             'loss': out.loss,

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -23,8 +23,8 @@ class HFModelWrapper(BaseModel):
         self.config = self.inner.config
         self.config.max_seq_len = self.inner.config.max_position_embeddings
         self.config.n_layers = self.inner.config.num_hidden_layers
-        self.config.n_heads  = self.inner.config.num_attention_heads
-        self.config.dim      = self.inner.config.hidden_size
+        self.config.n_heads = self.inner.config.num_attention_heads
+        self.config.dim = self.inner.config.hidden_size
         self.config.n_kv_heads = self.inner.config.num_key_value_heads
         self.pad_token_id = self.inner.config.pad_token_id
         self.vocab_size = self.inner.config.vocab_size

--- a/models/registry.py
+++ b/models/registry.py
@@ -1,11 +1,13 @@
 from config import ModelArchitecture
 from models.implementations.tendril import TendrilTransformer
 from models.implementations.tendril_moe import TendrilMoETransformer
+from models.implementations.hf_wrapper import HFModelWrapper
 
 
 MODEL_REGISTRY = {
     ModelArchitecture.TENDRIL: TendrilTransformer,
     ModelArchitecture.TENDRIL_MOE: TendrilMoETransformer,
+    ModelArchitecture.HF_WRAPPER: HFModelWrapper,
 }
 
 def build_model(*, config, pad_token_id, vocab_size, ignore_index):


### PR DESCRIPTION
Changes:
- Adds a wrapper class to load hf models directly as it is useful for debugging (Only CausalLM for now).
- When architecture is set to `hf_wrapper`, `model_name` becomes required which is the hf name. e.g.: 'HuggingFaceTB/SmolLM2-360M'.
- When using the wrapper the other architecture details are ignored (as we are loading a specific hf model)