### PR TITLE
Adding support for tied_embeddings

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,6 +77,7 @@ class ModelConfig(BaseModel):
     norm_eps: float = 1e-5
     rope_theta: float = 500000.0
     max_seq_len: int = 1024
+    tied_embeddings: bool = False
     moe: MoEConfig | None = None
 
 class PromptConfig(BaseModel):

--- a/models/implementations/tendril.py
+++ b/models/implementations/tendril.py
@@ -218,6 +218,8 @@ class TendrilTransformer(BaseModel):
 
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, self.vocab_size, bias=False)
+        if config.tied_embeddings:
+            self.output.weight = self.tok_embeddings.weight
 
         rope_freqs = precompute_rope_freqs(
             config.dim // config.n_heads,

--- a/models/implementations/tendril.py
+++ b/models/implementations/tendril.py
@@ -218,8 +218,6 @@ class TendrilTransformer(BaseModel):
 
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, self.vocab_size, bias=False)
-        if config.tied_embeddings:
-            self.output.weight = self.tok_embeddings.weight
 
         rope_freqs = precompute_rope_freqs(
             config.dim // config.n_heads,
@@ -230,6 +228,9 @@ class TendrilTransformer(BaseModel):
         self.register_buffer('rope_freqs', rope_freqs, persistent=False)
 
         self.init_model_weights()
+
+        if config.tied_embeddings:
+            self.output.weight = self.tok_embeddings.weight
 
     def init_model_weights(self):
         default_std = 0.02

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -348,8 +348,6 @@ class TendrilMoETransformer(BaseModel):
 
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, self.vocab_size, bias=False)
-        if config.tied_embeddings:
-            self.output.weight = self.tok_embeddings.weight
 
         rope_freqs = precompute_rope_freqs(
             config.dim // config.n_heads,
@@ -360,6 +358,9 @@ class TendrilMoETransformer(BaseModel):
         self.register_buffer('rope_freqs', rope_freqs, persistent=False)
 
         self.init_model_weights()
+
+        if config.tied_embeddings:
+            self.output.weight = self.tok_embeddings.weight
 
     def init_model_weights(self):
         default_std = 0.02

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -348,6 +348,8 @@ class TendrilMoETransformer(BaseModel):
 
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, self.vocab_size, bias=False)
+        if config.tied_embeddings:
+            self.output.weight = self.tok_embeddings.weight
 
         rope_freqs = precompute_rope_freqs(
             config.dim // config.n_heads,


### PR DESCRIPTION
Adds support for tied embeddings (output embedding weight points to input embeddings weight). Note that only applies to Tendril (dense and moe) at the moment.
Current logic in `optim.py` already handles deduplication, so the groups should be setup correctly.