### PR TITLE
Supporting direct load of hf checkpoint (model and tokenizer) in the inspector and runtime

### DIFF
--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -270,14 +270,14 @@ def load_checkpoint_for_inference(file_path) -> CheckpointDataInference:
         metadata=metadata
     )
 
-def load_shallow_hf_checkpoint_for_inference(hf_checkpoint_path: str, hf_tokenizer_path: str) -> HFCheckpointDataInference:
+def load_shallow_hf_checkpoint_for_inference(hf_checkpoint_path: str) -> HFCheckpointDataInference:
     # The purpose of this function is just to prepare the config abstraction.
     config = GlobalConfig()
     config.model = ModelConfig()
     config.model.architecture = 'hf_wrapper'
     config.model.hf_config = HFModelConfig()
     config.model.hf_config.model_name = hf_checkpoint_path
-    config.tokenizer.checkpoint_path = hf_tokenizer_path
+    config.tokenizer.checkpoint_path = hf_checkpoint_path
 
     return HFCheckpointDataInference(config=GlobalConfig.model_validate(config))
 

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -15,7 +15,7 @@ from torch.distributed.checkpoint.state_dict import (
 from logger import logger
 from dataclasses import dataclass, field
 from typing import Any
-from config import GlobalConfig
+from config import GlobalConfig, ModelConfig, HFModelConfig
 
 
 def state_to_cpu(obj):
@@ -211,13 +211,18 @@ def load_checkpoint(file_path) -> CheckpointData:
     )
 
 @dataclass
-class CheckpointDataInference:
+class BaseCheckpointDataInference:
+    pass
+
+@dataclass
+class CheckpointDataInference(BaseCheckpointDataInference):
     file_path: str
     config: GlobalConfig
     model_state: dict[str, Any]
     step: int
     is_lora_checkpoint: bool = False
     metadata: dict = field(default_factory=dict)
+    is_hf_direct_load: bool = False
 
     def to_dict(self):
         return {
@@ -225,7 +230,22 @@ class CheckpointDataInference:
             'config': self.config,
             'step': self.step,
             'is_lora_checkpoint': self.is_lora_checkpoint,
-            'metadata': self.metadata
+            'metadata': self.metadata,
+            'is_hf_direct_load': self.is_hf_direct_load
+        }
+
+    def __repr__(self):
+        return json.dumps(self.to_dict(), indent=4)
+
+@dataclass
+class HFCheckpointDataInference(BaseCheckpointDataInference):
+    config: GlobalConfig
+    is_hf_direct_load: bool = True
+
+    def to_dict(self):
+        return {
+            'config': self.config,
+            'is_hf_direct_load': self.is_hf_direct_load
         }
 
     def __repr__(self):
@@ -249,6 +269,17 @@ def load_checkpoint_for_inference(file_path) -> CheckpointDataInference:
         is_lora_checkpoint=metadata.get('lora_enabled', False),
         metadata=metadata
     )
+
+def load_shallow_hf_checkpoint_for_inference(hf_checkpoint_path: str, hf_tokenizer_path: str) -> HFCheckpointDataInference:
+    # The purpose of this function is just to prepare the config abstraction.
+    config = GlobalConfig()
+    config.model = ModelConfig()
+    config.model.architecture = 'hf_wrapper'
+    config.model.hf_config = HFModelConfig()
+    config.model.hf_config.model_name = hf_checkpoint_path
+    config.tokenizer.checkpoint_path = hf_tokenizer_path
+
+    return HFCheckpointDataInference(config=GlobalConfig.model_validate(config))
 
 def load_model_state(model, checkpoint_state_dict):
     if dist.is_initialized():

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -497,7 +497,8 @@ class Trainer:
             config=self.config.model,
             pad_token_id=self.tokenizer.pad_id,
             vocab_size=self.tokenizer.vocab_size,
-            ignore_index=self.config.tokenizer.ignore_index
+            ignore_index=self.config.tokenizer.ignore_index,
+            hf_token=self.config.third_party.hf_token if self.config.tokenizer.huggingface_tokenizer else None
         )
 
     def is_pretraining(self):

--- a/inference/checkpoint_inspector.py
+++ b/inference/checkpoint_inspector.py
@@ -16,7 +16,6 @@ class CheckpointInspector:
         *,
         checkpoint_path=None,
         hf_checkpoint_path=None,
-        hf_tokenizer_path=None,
         dtype=None,
         device=None,
         use_torch_compile=False,
@@ -34,13 +33,13 @@ class CheckpointInspector:
         if checkpoint_path is not None:
             checkpoint_data = load_checkpoint_for_inference(self.checkpoint_path)
         elif hf_checkpoint_path is not None:
-            checkpoint_data = load_shallow_hf_checkpoint_for_inference(
-                hf_checkpoint_path=hf_checkpoint_path,
-                hf_tokenizer_path=hf_tokenizer_path,
-            )
+            checkpoint_data = load_shallow_hf_checkpoint_for_inference(hf_checkpoint_path=hf_checkpoint_path)
             checkpoint_data.config.third_party.hf_token=hf_token
         else:
             raise ValueError('"checkpoint_path" or "hf_checkpoint_path" must be set.')
+
+        self.checkpoint_data = checkpoint_data
+        self.config = checkpoint_data.config
 
         self.inference_runtime = prepare_runtime_for_inference(
             checkpoint_data=checkpoint_data,

--- a/inference/checkpoint_inspector.py
+++ b/inference/checkpoint_inspector.py
@@ -1,26 +1,54 @@
 import torch
 import textwrap
 
-from engine.checkpoints import load_checkpoint_for_inference
+from engine.checkpoints import (
+    load_checkpoint_for_inference,
+    load_shallow_hf_checkpoint_for_inference
+)
 from inference.runtime import prepare_runtime_for_inference
 from inference.generation import generate_and_decode
 from logger import logger
 
 
 class CheckpointInspector:
-    def __init__(self, *, checkpoint_path, dtype=None, device=None, use_torch_compile=False, text_width=160):
+    def __init__(
+        self,
+        *,
+        checkpoint_path=None,
+        hf_checkpoint_path=None,
+        hf_tokenizer_path=None,
+        dtype=None,
+        device=None,
+        use_torch_compile=False,
+        text_width=160,
+        hf_token=None
+    ):
         logger.set_master(True)
+
+        if checkpoint_path is not None and hf_checkpoint_path is not None:
+            raise ValueError('"checkpoint_path" and "hf_checkpoint_path" are mutually exclusive.')
 
         self.checkpoint_path = checkpoint_path
         self.use_torch_compile = use_torch_compile
-        self.checkpoint_data = load_checkpoint_for_inference(self.checkpoint_path)
-        self.config = self.checkpoint_data.config
+
+        if checkpoint_path is not None:
+            checkpoint_data = load_checkpoint_for_inference(self.checkpoint_path)
+        elif hf_checkpoint_path is not None:
+            checkpoint_data = load_shallow_hf_checkpoint_for_inference(
+                hf_checkpoint_path=hf_checkpoint_path,
+                hf_tokenizer_path=hf_tokenizer_path,
+            )
+            checkpoint_data.config.third_party.hf_token=hf_token
+        else:
+            raise ValueError('"checkpoint_path" or "hf_checkpoint_path" must be set.')
+
         self.inference_runtime = prepare_runtime_for_inference(
-            checkpoint_data=self.checkpoint_data,
-            dtype=dtype if dtype is not None else self.config.runtime.training_precision.value,
-            device=device if device is not None else self.config.runtime.device_type.value,
+            checkpoint_data=checkpoint_data,
+            dtype=dtype if dtype is not None else checkpoint_data.config.runtime.training_precision.value,
+            device=device if device is not None else checkpoint_data.config.runtime.device_type.value,
             use_torch_compile=self.use_torch_compile
         )
+
         self.model = self.inference_runtime.model
         self.tokenizer = self.inference_runtime.tokenizer
         self.device = self.inference_runtime.device

--- a/inference/runtime.py
+++ b/inference/runtime.py
@@ -1,7 +1,7 @@
 import torch
 
 from dataclasses import dataclass
-from config import TrainingPrecision, GlobalConfig, ModelConfig, HFModelConfig
+from config import TrainingPrecision, GlobalConfig
 from tokenization.tokenizer import init_tokenizer
 from models.registry import build_model
 from models.adapters.lora import apply_lora

--- a/inference/runtime.py
+++ b/inference/runtime.py
@@ -1,12 +1,13 @@
 import torch
 
 from dataclasses import dataclass
-from config import TrainingPrecision, GlobalConfig
+from config import TrainingPrecision, GlobalConfig, ModelConfig, HFModelConfig
 from tokenization.tokenizer import init_tokenizer
 from models.registry import build_model
 from models.adapters.lora import apply_lora
+from models.implementations.hf_wrapper import HFModelWrapper
 from engine.checkpoints import (
-    CheckpointDataInference,
+    BaseCheckpointDataInference,
     load_model_state
 )
 
@@ -19,24 +20,43 @@ class InferenceRuntime:
     dtype: torch.dtype
     device: str
 
-def init_tokenizer_and_model(config: GlobalConfig):
+def init_tokenizer_and_model(checkpoint_data: BaseCheckpointDataInference):
+    config = checkpoint_data.config
+    hf_token = config.third_party.hf_token if config.tokenizer.huggingface_tokenizer else None
+
     tokenizer = init_tokenizer(
         path=config.tokenizer.checkpoint_path,
         system_prompt=config.prompts.system_prompt,
         is_huggingface_tokenizer=config.tokenizer.huggingface_tokenizer,
-        hf_token=config.third_party.hf_token if config.tokenizer.huggingface_tokenizer else None
+        hf_token=hf_token
     )
 
     model = build_model(
         config=config.model,
         pad_token_id=tokenizer.pad_id,
         vocab_size=tokenizer.vocab_size,
-        ignore_index=config.tokenizer.ignore_index
+        ignore_index=config.tokenizer.ignore_index,
+        hf_token=hf_token
     )
+
+    if not checkpoint_data.is_hf_direct_load:
+        if checkpoint_data.is_lora_checkpoint:
+            apply_lora(
+                model=model,
+                target_modules=checkpoint_data.config.lora.target_modules,
+                rank=checkpoint_data.config.lora.rank,
+                alpha=checkpoint_data.config.lora.alpha,
+                dropout=checkpoint_data.config.lora.dropout
+            )
+
+        load_model_state(model, checkpoint_data.model_state)
 
     return tokenizer, model
 
-def resolve_inference_dtype(dtype: str, config: GlobalConfig) -> torch.dtype:
+def resolve_inference_dtype(dtype: str) -> torch.dtype:
+    if dtype is None or dtype == 'auto':
+        return torch.bfloat16 if torch.cuda.is_available() else torch.float32
+
     if dtype == 'bf16':
         return torch.bfloat16
     if dtype == 'fp16':
@@ -44,39 +64,18 @@ def resolve_inference_dtype(dtype: str, config: GlobalConfig) -> torch.dtype:
     if dtype == 'fp32':
         return torch.float32
 
-    if dtype != 'auto':
-        raise ValueError(f'Unsupported dtype: {dtype}')
-
-    if config.runtime.training_precision == TrainingPrecision.BF16:
-        return torch.bfloat16
-    if config.runtime.training_precision == TrainingPrecision.FP16:
-        return torch.float16
-
-    return torch.float32
+    raise ValueError(f'Unsupported dtype: {dtype}')
 
 def prepare_runtime_for_inference(
     *,
-    checkpoint_data: CheckpointDataInference,
+    checkpoint_data: BaseCheckpointDataInference,
     dtype: str,
     device: str,
     use_torch_compile: bool
 ):
-    config = checkpoint_data.config
+    tokenizer, model = init_tokenizer_and_model(checkpoint_data)
 
-    tokenizer, model = init_tokenizer_and_model(config)
-
-    if checkpoint_data.is_lora_checkpoint:
-        apply_lora(
-            model=model,
-            target_modules=config.lora.target_modules,
-            rank=config.lora.rank,
-            alpha=config.lora.alpha,
-            dropout=config.lora.dropout
-        )
-
-    load_model_state(model, checkpoint_data.model_state)
-
-    dtype = resolve_inference_dtype(dtype=dtype, config=config)
+    dtype = resolve_inference_dtype(dtype=dtype)
 
     model.to(device=device, dtype=dtype)
     model.eval()
@@ -85,7 +84,7 @@ def prepare_runtime_for_inference(
         model.compile()
 
     return InferenceRuntime(
-        config=config,
+        config=checkpoint_data.config,
         model=model,
         tokenizer=tokenizer,
         dtype=dtype,

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -14,6 +14,7 @@ class HFModelWrapper(BaseModel):
         pad_token_id: int,
         vocab_size: int,
         ignore_index: int,
+        hf_token: str
     ):
         super().__init__(
             config=config,
@@ -26,9 +27,9 @@ class HFModelWrapper(BaseModel):
 
         if config.hf_config.random_init:
             logger.warning('"random_init" flag set. The weights will be randomly initialized.')
-            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name))
+            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name, token=hf_token), token=hf_token)
         else:
-            self.inner = AutoModelForCausalLM.from_pretrained(config.hf_config.model_name)
+            self.inner = AutoModelForCausalLM.from_pretrained(config.hf_config.model_name, token=hf_token)
         if self.inner.config.vocab_size != vocab_size:
             raise ValueError(
                 f'Tokenizer vocab_size={vocab_size} != HF model vocab_size={self.inner.config.vocab_size}. '

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -27,7 +27,7 @@ class HFModelWrapper(BaseModel):
 
         if config.hf_config.random_init:
             logger.warning('"random_init" flag set. The weights will be randomly initialized.')
-            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name, token=hf_token), token=hf_token)
+            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name), token=hf_token)
         else:
             self.inner = AutoModelForCausalLM.from_pretrained(config.hf_config.model_name, token=hf_token)
         if self.inner.config.vocab_size != vocab_size:

--- a/models/implementations/hf_wrapper.py
+++ b/models/implementations/hf_wrapper.py
@@ -27,7 +27,7 @@ class HFModelWrapper(BaseModel):
 
         if config.hf_config.random_init:
             logger.warning('"random_init" flag set. The weights will be randomly initialized.')
-            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name), token=hf_token)
+            self.inner = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(config.hf_config.model_name, token=hf_token))
         else:
             self.inner = AutoModelForCausalLM.from_pretrained(config.hf_config.model_name, token=hf_token)
         if self.inner.config.vocab_size != vocab_size:

--- a/models/registry.py
+++ b/models/registry.py
@@ -10,16 +10,20 @@ MODEL_REGISTRY = {
     ModelArchitecture.HF_WRAPPER: HFModelWrapper,
 }
 
-def build_model(*, config, pad_token_id, vocab_size, ignore_index):
+def build_model(*, config, pad_token_id, vocab_size, ignore_index, hf_token=None):
     model_cls = MODEL_REGISTRY.get(config.architecture)
     if model_cls is None:
         raise ValueError(f'Invalid model architecture: {config.architecture}')
 
     model_cls.validate_config(config)
 
-    return model_cls(
-        config=config,
-        pad_token_id=pad_token_id,
-        vocab_size=vocab_size,
-        ignore_index=ignore_index,
-    )
+    kwargs = {
+        'config': config,
+        'pad_token_id': pad_token_id,
+        'vocab_size': vocab_size,
+        'ignore_index': ignore_index
+    }
+    if model_cls == HFModelWrapper:
+        kwargs['hf_token'] = hf_token
+
+    return model_cls(**kwargs)


### PR DESCRIPTION
Relates to #102  (part 1)

Changes:
- Modifies the inspector and runtime to be able to run a FH checkpoint directly (without needing a specific local checkpoint path)