### PR TITLE
Support for multi turn chat

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,19 +9,6 @@ from typing import Any, Annotated, Literal
 from logger import logger
 
 
-class DeviceType(str, Enum):
-    CUDA = 'cuda'
-
-class TrainingStage(str, Enum):
-    PRETRAINING = 'pretraining'
-    INSTRUCT = 'instruct'
-    DPO = 'dpo'
-
-class TrainingPrecision(str, Enum):
-    BF16 = 'bf16'
-    FP16 = 'fp16'
-    FP32 = 'fp32'
-
 class RunConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     name: str | None = None
@@ -37,6 +24,14 @@ class DatasetPreparationConfig(BaseModel):
     mp_pool_chunk_size: int = 64
     hf_map_batch_size: int = 1000
     hf_map_writer_batch_size: int = 1000
+
+class DeviceType(str, Enum):
+    CUDA = 'cuda'
+
+class TrainingPrecision(str, Enum):
+    BF16 = 'bf16'
+    FP16 = 'fp16'
+    FP32 = 'fp32'
 
 class RuntimeConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -83,6 +78,11 @@ class ModelConfig(BaseModel):
 class PromptConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     system_prompt: str = 'You are a helpful AI assistant.'
+
+class TrainingStage(str, Enum):
+    PRETRAINING = 'pretraining'
+    INSTRUCT = 'instruct'
+    DPO = 'dpo'
 
 class TrainingConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -150,11 +150,16 @@ class GenerationConfig(BaseModel):
     run_on_last_step: bool = False
     test_prompts: list[str] | None = None
 
+class TokenizerPromptFormat(str, Enum):
+    GRADIENT_GARDEN = 'gradient_garden'
+    HF_CHAT_TEMPLATE = 'hf_chat_template'
+
 class TokenizerConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
     checkpoint_path: str = 'HuggingFaceTB/SmolLM2-360M'
     huggingface_tokenizer: bool = True
     ignore_index: int = -100
+    prompt_format: TokenizerPromptFormat = TokenizerPromptFormat.GRADIENT_GARDEN
 
 class LoRAConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')

--- a/engine/checkpoints.py
+++ b/engine/checkpoints.py
@@ -15,7 +15,7 @@ from torch.distributed.checkpoint.state_dict import (
 from logger import logger
 from dataclasses import dataclass, field
 from typing import Any
-from config import GlobalConfig, ModelConfig, HFModelConfig
+from config import GlobalConfig, ModelConfig, HFModelConfig, TokenizerPromptFormat
 
 
 def state_to_cpu(obj):
@@ -278,6 +278,7 @@ def load_shallow_hf_checkpoint_for_inference(hf_checkpoint_path: str) -> HFCheck
     config.model.hf_config = HFModelConfig()
     config.model.hf_config.model_name = hf_checkpoint_path
     config.tokenizer.checkpoint_path = hf_checkpoint_path
+    config.tokenizer.prompt_format = TokenizerPromptFormat.HF_CHAT_TEMPLATE
 
     return HFCheckpointDataInference(config=GlobalConfig.model_validate(config))
 

--- a/inference/checkpoint_inspector.py
+++ b/inference/checkpoint_inspector.py
@@ -70,7 +70,8 @@ class CheckpointInspector:
         use_kv_cache=False,
         batch_size=1,
         skip_encoding=False,
-        print_text=True
+        print_text=True,
+        prompts_are_messages=False
     ):
         with torch.autocast(
             device_type=self.device_type,
@@ -92,7 +93,8 @@ class CheckpointInspector:
                 is_instruct=instruct,
                 use_kv_cache=use_kv_cache,
                 batch_size=batch_size,
-                skip_encoding=skip_encoding
+                skip_encoding=skip_encoding,
+                prompts_are_messages=prompts_are_messages
             )
 
         results = [

--- a/inference/generation.py
+++ b/inference/generation.py
@@ -313,8 +313,14 @@ def generate_and_decode(
         batch_size,
         skip_encoding=False,
         show_progress=False,
-        progress_bar_label=None
+        progress_bar_label=None,
+        prompts_are_messages=False
     ):
+        if full_seq and prompts_are_messages:
+            raise ValueError('full_seq=True is not supported with prompts_are_messages=True')
+        if not is_instruct and prompts_are_messages:
+            raise ValueError('prompts_are_messages=True requires is_instruct=True')
+
         vocab_size = tokenizer.vocab_size
         pad_token_id = tokenizer.pad_id
 
@@ -325,10 +331,19 @@ def generate_and_decode(
             batch_size = len(prompts)
 
         if not skip_encoding:
-            prompt_tokens = [
-                tokenizer.encode_instruct_inference(prompt) if is_instruct else tokenizer.encode(prompt)
-                for prompt in prompts
-            ]
+            if is_instruct:
+                if prompts_are_messages:
+                    prompt_tokens = [
+                        tokenizer.encode_instruct_messages_inference(prompt)
+                        for prompt in prompts
+                    ]
+                else:
+                    prompt_tokens = [
+                        tokenizer.encode_instruct_inference(prompt)
+                        for prompt in prompts
+                    ]
+            else:
+                prompt_tokens = [tokenizer.encode(prompt) for prompt in prompts]
         else:
             prompt_tokens = prompts
 

--- a/inference/runtime.py
+++ b/inference/runtime.py
@@ -10,7 +10,6 @@ from engine.checkpoints import (
     BaseCheckpointDataInference,
     load_model_state
 )
-from config import TokenizerPromptFormat
 
 
 @dataclass(frozen=True)
@@ -30,11 +29,7 @@ def init_tokenizer_and_model(checkpoint_data: BaseCheckpointDataInference):
         system_prompt=config.prompts.system_prompt,
         is_huggingface_tokenizer=config.tokenizer.huggingface_tokenizer,
         hf_token=hf_token,
-        prompt_format=(
-            TokenizerPromptFormat.HF_CHAT_TEMPLATE
-            if checkpoint_data.is_hf_direct_load
-            else TokenizerPromptFormat.GRADIENT_GARDEN
-        )
+        prompt_format=config.tokenizer.prompt_format
     )
 
     model = build_model(

--- a/inference/runtime.py
+++ b/inference/runtime.py
@@ -10,6 +10,7 @@ from engine.checkpoints import (
     BaseCheckpointDataInference,
     load_model_state
 )
+from config import TokenizerPromptFormat
 
 
 @dataclass(frozen=True)
@@ -28,7 +29,12 @@ def init_tokenizer_and_model(checkpoint_data: BaseCheckpointDataInference):
         path=config.tokenizer.checkpoint_path,
         system_prompt=config.prompts.system_prompt,
         is_huggingface_tokenizer=config.tokenizer.huggingface_tokenizer,
-        hf_token=hf_token
+        hf_token=hf_token,
+        prompt_format=(
+            TokenizerPromptFormat.HF_CHAT_TEMPLATE
+            if checkpoint_data.is_hf_direct_load
+            else TokenizerPromptFormat.GRADIENT_GARDEN
+        )
     )
 
     model = build_model(

--- a/tokenization/base.py
+++ b/tokenization/base.py
@@ -86,16 +86,34 @@ class BaseTokenizer(ABC):
     def decode(self, ids):
         ...
 
-    def encode_instruct_inference(self, text: str, system_msg: bool = True):
+    def encode_instruct_messages_inference(self, messages):
         builder = PromptBuilder(self, no_labels=True)
 
-        if system_msg:
-            builder.add_message('system', self.system_prompt)
+        for message in messages:
+            builder.add_message(
+                message['role'],
+                message['content'],
+            )
 
-        builder.add_message('user', text)
         builder.add_assistant_prefix()
 
         return builder.build()
+
+    def encode_instruct_inference(self, text: str, system_msg: bool = True):
+        messages = []
+
+        if system_msg:
+            messages.append({
+                'role': 'system',
+                'content': self.system_prompt,
+            })
+
+        messages.append({
+            'role': 'user',
+            'content': text,
+        })
+
+        return self.encode_instruct_messages_inference(messages)
 
     def encode_instruct_chat(
         self,

--- a/tokenization/hf_tokenizer.py
+++ b/tokenization/hf_tokenizer.py
@@ -1,9 +1,10 @@
 from tokenization.base import BaseTokenizer
 from transformers import AutoTokenizer
+from config import TokenizerPromptFormat
 
 
 class HFTokenizer(BaseTokenizer):
-    def __init__(self, path, system_prompt, hf_token):
+    def __init__(self, path: str, system_prompt: str, hf_token: str, prompt_format: TokenizerPromptFormat):
         self.model = AutoTokenizer.from_pretrained(path, token=hf_token)
         self.model.model_max_length = int(1e30)
         self.system_prompt = system_prompt
@@ -23,8 +24,45 @@ class HFTokenizer(BaseTokenizer):
 
         self.stop_tokens = {self.eos_id}
 
+        self.prompt_format = prompt_format
+
     def encode(self, text, add_special_tokens=False):
         return self.model.encode(text, add_special_tokens=add_special_tokens)
 
     def decode(self, tokens, skip_special_tokens=False):
         return self.model.decode(tokens, skip_special_tokens=skip_special_tokens)
+
+    def encode_instruct_inference(self, text: str, system_msg: bool = True):
+        if self.prompt_format == TokenizerPromptFormat.HF_CHAT_TEMPLATE:
+            messages = []
+
+            if system_msg:
+                messages.append({
+                    'role': 'system',
+                    'content': self.system_prompt,
+                })
+
+            messages.append({
+                'role': 'user',
+                'content': text,
+            })
+
+            return self.model.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=False
+            )
+
+        return super().encode_instruct_inference(text, system_msg=system_msg)
+
+    def encode_instruct_messages_inference(self, messages):
+        if self.prompt_format == TokenizerPromptFormat.HF_CHAT_TEMPLATE:
+            return self.model.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=False,
+            )
+
+        return super().encode_instruct_messages_inference(messages)

--- a/tokenization/hf_tokenizer.py
+++ b/tokenization/hf_tokenizer.py
@@ -32,30 +32,6 @@ class HFTokenizer(BaseTokenizer):
     def decode(self, tokens, skip_special_tokens=False):
         return self.model.decode(tokens, skip_special_tokens=skip_special_tokens)
 
-    def encode_instruct_inference(self, text: str, system_msg: bool = True):
-        if self.prompt_format == TokenizerPromptFormat.HF_CHAT_TEMPLATE:
-            messages = []
-
-            if system_msg:
-                messages.append({
-                    'role': 'system',
-                    'content': self.system_prompt,
-                })
-
-            messages.append({
-                'role': 'user',
-                'content': text,
-            })
-
-            return self.model.apply_chat_template(
-                messages,
-                tokenize=True,
-                add_generation_prompt=True,
-                return_dict=False
-            )
-
-        return super().encode_instruct_inference(text, system_msg=system_msg)
-
     def encode_instruct_messages_inference(self, messages):
         if self.prompt_format == TokenizerPromptFormat.HF_CHAT_TEMPLATE:
             return self.model.apply_chat_template(

--- a/tokenization/tokenizer.py
+++ b/tokenization/tokenizer.py
@@ -1,7 +1,15 @@
 from tokenization.hf_tokenizer import HFTokenizer
+from config import TokenizerPromptFormat
 
 
-def init_tokenizer(*, path, system_prompt, is_huggingface_tokenizer=True, hf_token=None):
+def init_tokenizer(
+    *,
+    path,
+    system_prompt,
+    is_huggingface_tokenizer=True,
+    hf_token=None,
+    prompt_format=TokenizerPromptFormat.GRADIENT_GARDEN
+):
     if is_huggingface_tokenizer is True:
-        return HFTokenizer(path, system_prompt, hf_token)
+        return HFTokenizer(path, system_prompt, hf_token, prompt_format)
     raise ValueError('Currently only HF tokenizer is supported.')


### PR DESCRIPTION
Relates to #102 

Changes:
- Support to multi turn messages encoding.
- Modification in the tokenizer to have two instruct prompt format paths: `GRADIENT_GARDEN` and `HF_CHAT_TEMPLATE`.
- Adds `prompts_are_messages` flag to `generate_and_decode`.

Note: When enabled the `prompts` param becomes a list of message lists, for example:
```
[
    [
        {'role': 'system', 'content': 'You are a helpful AI agent.'},
        {'role': 'user', 'content': 'Can you help me planning a trip?'},
        {'role': 'assistant', 'content': "Absolutely, I'd be happy to help you plan your trip. Please provide me with some details about your trip, such as:  1. Destination: What country or region are you planning to visit? 2. Duration: How long do you plan to stay? 3. Budget: What is your estimated budget for the trip? 4. Interests: Are there any specific activities or experiences you want to have during your trip? 5. Preferences: Are there any particular places you want to visit, or any specific activities you want to do?  Once I have this information, I can start suggesting"},
        {'role': 'user', 'content': 'Suggest only one where to go first.'}
    ]
]
```