### PR TITLE
Removing attention_mask from MC evals

### DIFF
--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1251,14 +1251,15 @@ class Trainer:
             disable=not is_master_process,
             leave=False
         ):
-            tokens, mask, attention_mask, label_index, valid = example['tokens'], example['mask'], example['attention_mask'], example['label_index'], example['valid']
+            tokens, mask, label_index, valid = example['tokens'], example['mask'], example['label_index'], example['valid']
 
             tokens = tokens.to(device)
             mask = mask.to(device)
-            attention_mask = attention_mask.to(device)
 
             with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
-                logits = self.model(tokens, attention_mask=attention_mask)['logits']
+                # MC eval examples are right padded. For causal LM scoring, real tokens cannot attend to future pad tokens, and mask excludes pad target positions from the loss.
+                # Passing attention_mask here is redundant and triggers a torch.compile error..
+                logits = self.model(tokens)['logits']
 
             if not valid:
                 # We want all ranks to still call forward()...

--- a/evals/multiple_choice.py
+++ b/evals/multiple_choice.py
@@ -17,7 +17,6 @@ def load_multiple_choice_eval_file(
         example = json.loads(line)
         tokens = torch.tensor(example['tokens'], dtype=torch.long)
         scoring_mask = torch.tensor(example['mask'], dtype=torch.long)
-        attention_mask = (tokens != pad_token_id).long()
         label_index = int(example['label_index'])
 
         assert tokens.ndim == 2
@@ -26,7 +25,6 @@ def load_multiple_choice_eval_file(
         return {
             'tokens': tokens,
             'mask': scoring_mask,
-            'attention_mask': attention_mask,
             'label_index': label_index,
             'valid': True
         }
@@ -36,7 +34,6 @@ def load_multiple_choice_eval_file(
         return {
             'tokens': tokens,
             'mask': torch.zeros_like(tokens),
-            'attention_mask': torch.ones_like(tokens),
             'label_index': -1,
             'valid': False
         }


### PR DESCRIPTION
As explained in my comment the multiple choice evals examples are right padded. For causal LM scoring, real tokens cannot attend to future pad tokens, and the mask excludes pad target positions from the loss which means it should be correct.

The `attention_mask` here is redundant and triggers a torch.compile error.