### PR TITLE
fix post training loss calculation

### DIFF
--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1078,7 +1078,7 @@ class Trainer:
 
             # Instead of scaling the loss by grad_accum_steps inside of the task, we now scale the gradients by the number of valid tokens.
             # This is better than the previous and also compatible with pretraining, sft, etc.
-            # DDP already gives token grads / world size, but we want token grads / num valid tokens, so we multiply by (world_size / num valid tokens).
+            # DDP/FSDP averages parameter gradients across ranks, but we want token grads / num valid tokens, so we multiply by (world_size / num valid tokens).
             grad_scale = self.trainer_ctx.distributed.ddp_world_size / valid_tokens_sum.clamp_min(1).item()
         else:
             grad_scale = 1.0 / valid_tokens_sum.clamp_min(1).item()

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1025,6 +1025,21 @@ class Trainer:
             if self.optimizers.muon:
                 self.optimizers.muon.step()
 
+    def scale_gradients_by_n_valid(self, valid_tokens_sum):
+        # Tasks return loss_for_backward as a summed objective numerator and n_valid as its denominator.
+        # We backprop summed local losses, then scale synchronized gradients once by the global denominator.
+        # For pretraining this matches loss / grad_accum_steps because each microbatch has the same valid token count.
+        # For SFT it correctly handles different numbers of supervised assistant tokens per microbatch/rank.
+        # DDP/FSDP average gradients across ranks, so after backpropagating summed local losses we multiply by
+        # world_size / global_n_valid to get the global mean objective gradient.
+        grad_scale = self.trainer_ctx.distributed.ddp_world_size / valid_tokens_sum.clamp_min(1).item()
+
+        for p in self.model.parameters():
+            if p.grad is not None:
+                p.grad.mul_(grad_scale)
+
+        return grad_scale
+
     def run_train(self, pbar):
         ddp = self.trainer_ctx.distributed.ddp
         ddp_local_rank = self.trainer_ctx.distributed.ddp_local_rank
@@ -1076,16 +1091,7 @@ class Trainer:
             dist.all_reduce(tokens_processed_sum, op=dist.ReduceOp.SUM)
             dist.all_reduce(valid_tokens_sum, op=dist.ReduceOp.SUM)
 
-            # Instead of scaling the loss by grad_accum_steps inside of the task, we now scale the gradients by the number of valid tokens.
-            # This is better than the previous and also compatible with pretraining, sft, etc.
-            # DDP/FSDP averages parameter gradients across ranks, but we want token grads / num valid tokens, so we multiply by (world_size / num valid tokens).
-            grad_scale = self.trainer_ctx.distributed.ddp_world_size / valid_tokens_sum.clamp_min(1).item()
-        else:
-            grad_scale = 1.0 / valid_tokens_sum.clamp_min(1).item()
-
-        for p in self.model.parameters():
-            if p.grad is not None:
-                p.grad.mul_(grad_scale)
+        self.scale_gradients_by_n_valid(valid_tokens_sum)
 
         norm = self.clip_grad_norm(self.model, 1.0)
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1025,14 +1025,14 @@ class Trainer:
             if self.optimizers.muon:
                 self.optimizers.muon.step()
 
-    def scale_gradients_by_n_valid(self, valid_tokens_sum):
+    def scale_gradients_by_n_valid(self, n_valid_sum):
         # Tasks return loss_for_backward as a summed objective numerator and n_valid as its denominator.
         # We backprop summed local losses, then scale synchronized gradients once by the global denominator.
         # For pretraining this matches loss / grad_accum_steps because each microbatch has the same valid token count.
         # For SFT it correctly handles different numbers of supervised assistant tokens per microbatch/rank.
         # DDP/FSDP average gradients across ranks, so after backpropagating summed local losses we multiply by
         # world_size / global_n_valid to get the global mean objective gradient.
-        grad_scale = self.trainer_ctx.distributed.ddp_world_size / valid_tokens_sum.clamp_min(1).item()
+        grad_scale = self.trainer_ctx.distributed.ddp_world_size / n_valid_sum.clamp_min(1).item()
 
         for p in self.model.parameters():
             if p.grad is not None:
@@ -1048,7 +1048,7 @@ class Trainer:
         scaler = self.trainer_ctx.precision.scaler
         grad_accum_steps = self.trainer_ctx.grad_accum_steps
         tokens_processed_sum = torch.tensor(0.0, device=device)
-        valid_tokens_sum = torch.tensor(0.0, device=device)
+        n_valid_sum = torch.tensor(0.0, device=device)
         console_logs = []
         metrics_sum_acc = {}
         metrics_weights_acc = {}
@@ -1064,7 +1064,7 @@ class Trainer:
         for micro_step in range(grad_accum_steps):
             output = self.task.train_micro_step(self.model, self.train_loader.next_batch(), self.task_assets)
             tokens_processed_sum += output.tokens_processed
-            valid_tokens_sum += output.n_valid.to(device=device, dtype=torch.float32)
+            n_valid_sum += output.n_valid.to(device=device, dtype=torch.float32)
             loss_for_backward = output.loss_for_backward
 
             console_logs.extend(output.console_logs)
@@ -1089,9 +1089,9 @@ class Trainer:
 
         if ddp:
             dist.all_reduce(tokens_processed_sum, op=dist.ReduceOp.SUM)
-            dist.all_reduce(valid_tokens_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(n_valid_sum, op=dist.ReduceOp.SUM)
 
-        self.scale_gradients_by_n_valid(valid_tokens_sum)
+        self.scale_gradients_by_n_valid(n_valid_sum)
 
         norm = self.clip_grad_norm(self.model, 1.0)
 

--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -1033,6 +1033,7 @@ class Trainer:
         scaler = self.trainer_ctx.precision.scaler
         grad_accum_steps = self.trainer_ctx.grad_accum_steps
         tokens_processed_sum = torch.tensor(0.0, device=device)
+        valid_tokens_sum = torch.tensor(0.0, device=device)
         console_logs = []
         metrics_sum_acc = {}
         metrics_weights_acc = {}
@@ -1048,7 +1049,8 @@ class Trainer:
         for micro_step in range(grad_accum_steps):
             output = self.task.train_micro_step(self.model, self.train_loader.next_batch(), self.task_assets)
             tokens_processed_sum += output.tokens_processed
-            loss_scaled = output.loss_for_backward
+            valid_tokens_sum += output.n_valid.to(device=device, dtype=torch.float32)
+            loss_for_backward = output.loss_for_backward
 
             console_logs.extend(output.console_logs)
             accumulate_weighted_metrics(
@@ -1063,16 +1065,27 @@ class Trainer:
                 self.model.require_backward_grad_sync = (micro_step == grad_accum_steps - 1)
 
             if scaler:
-                scaler.scale(loss_scaled).backward()
+                scaler.scale(loss_for_backward).backward()
             else:
-                loss_scaled.backward()
-
-        if ddp:
-            dist.all_reduce(tokens_processed_sum, op=dist.ReduceOp.SUM)
-        tokens_processed_sum = tokens_processed_sum.item()
+                loss_for_backward.backward()
 
         if scaler:
             self.unscale_optimizers(scaler)
+
+        if ddp:
+            dist.all_reduce(tokens_processed_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(valid_tokens_sum, op=dist.ReduceOp.SUM)
+
+            # Instead of scaling the loss by grad_accum_steps inside of the task, we now scale the gradients by the number of valid tokens.
+            # This is better than the previous and also compatible with pretraining, sft, etc.
+            # DDP already gives token grads / world size, but we want token grads / num valid tokens, so we multiply by (world_size / num valid tokens).
+            grad_scale = self.trainer_ctx.distributed.ddp_world_size / valid_tokens_sum.clamp_min(1).item()
+        else:
+            grad_scale = 1.0 / valid_tokens_sum.clamp_min(1).item()
+
+        for p in self.model.parameters():
+            if p.grad is not None:
+                p.grad.mul_(grad_scale)
 
         norm = self.clip_grad_norm(self.model, 1.0)
 
@@ -1083,7 +1096,7 @@ class Trainer:
         t1.record()
         t1.synchronize()
         dt = t0.elapsed_time(t1) / 1000.0
-        tokens_per_sec = int(tokens_processed_sum / dt)
+        tokens_per_sec = int(tokens_processed_sum.item() / dt)
 
         step_metrics = StepMetrics(
             step_type=StepType.TRAIN,

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -200,7 +200,7 @@ class MoEFeedForward(nn.Module):
         self.acc_p_sum.add_(p.to(torch.float32) * n_tokens)
         self.acc_tokens.add_(n_tokens)
 
-    def forward(self, x):
+    def forward(self, x, router_loss_mask=None):
         B, S, D = x.shape
         x_flat = x.reshape(B * S, D)
         y_flat = torch.zeros_like(x_flat)
@@ -210,28 +210,53 @@ class MoEFeedForward(nn.Module):
         top_k_logits, top_k_index = torch.topk(logits, k=self.top_k, dim=-1) # (B*S, E_logits) / (B*S, E_indexes)
 
         top_k_probs = F.softmax(top_k_logits, dim=-1, dtype=x_flat.dtype)
-        all_probs = F.softmax(logits, dim=-1, dtype=x_flat.dtype)
+
+        # These counts describe the routing for every token.
+        full_topk_counts_i64 = torch.bincount(
+            top_k_index.reshape(-1),
+            minlength=self.num_experts,
+        ).to(torch.int64)
+
+        aux_logits = logits
+        aux_top_k_index = top_k_index
+        if router_loss_mask is not None:
+            flat_mask = router_loss_mask.reshape(-1).to(
+                device=logits.device,
+                dtype=torch.bool
+            )
+
+            if flat_mask.numel() != B * S:
+                raise ValueError(
+                    'router_loss_mask must have one entry per input token'
+                )
+
+            if not flat_mask.any().item():
+                raise ValueError(
+                    'MoE auxiliary loss has no valid supervised tokens'
+                )
+
+            aux_logits = logits[flat_mask]
+            aux_top_k_index = top_k_index[flat_mask]
 
         # TOKEN LOAD BALANCE
         # f
-        total_token_count_possible = B * S * self.top_k
-
-        topk_counts_i64 = torch.bincount(top_k_index.reshape(-1), minlength=self.num_experts).to(torch.int64)
-        counts_per_top_k_expert = topk_counts_i64.to(torch.float32)
-        f = counts_per_top_k_expert / max(1.0, total_token_count_possible)
+        aux_topk_counts_i64 = torch.bincount(aux_top_k_index.reshape(-1), minlength=self.num_experts).to(torch.int64)
+        aux_topk_counts = aux_topk_counts_i64.to(torch.float32)
+        f = aux_topk_counts / max(1.0, aux_top_k_index.numel())
         # p
-        p = all_probs.mean(dim=0)
+        p = F.softmax(aux_logits, dim=-1, dtype=x_flat.dtype).mean(dim=0)
         load_balance_loss = self.load_balancing_coef * self.num_experts * torch.sum(f * p)
 
         # Z LOSS
-        z_loss = self.z_loss_coef * torch.mean(torch.logsumexp(logits, dim=-1) ** 2.0)
+        z_loss = self.z_loss_coef * torch.mean(torch.logsumexp(aux_logits, dim=-1) ** 2.0)
 
         aux_loss = load_balance_loss + z_loss
 
         # COMPUTE STATS
         if self.compute_stats:
             with torch.no_grad():
-                self._accumulate_stats(top_k_index, topk_counts_i64, p)
+                full_p = F.softmax(logits, dim=-1, dtype=x_flat.dtype).mean(dim=0)
+                self._accumulate_stats(top_k_index, full_topk_counts_i64, full_p)
 
         # PERFORMANCE
         flat_top_k_index = top_k_index.reshape(-1)
@@ -243,8 +268,7 @@ class MoEFeedForward(nn.Module):
         flat_top_k_probs = flat_top_k_probs.index_select(0, order)
         flat_token = flat_token.index_select(0, order)
 
-        counts = counts_per_top_k_expert.int()
-        offsets = torch.cumsum(counts, dim=0)
+        offsets = torch.cumsum(full_topk_counts_i64, dim=0)
         starts = torch.empty_like(offsets)
         starts[0] = 0
         starts[1:] = offsets[:-1]
@@ -254,8 +278,8 @@ class MoEFeedForward(nn.Module):
             e_i = offsets[i]
             if s_i == e_i:
                 if torch.is_grad_enabled():
-                    for p in self.experts[i].parameters(): # hack so the autograd graph considers the expert (otherwise error because of None grad)
-                        aux_loss = aux_loss + p.sum() * 0.0
+                    for parameter in self.experts[i].parameters(): # hack so the autograd graph considers the expert (otherwise error because of None grad)
+                        aux_loss = aux_loss + parameter.sum() * 0.0
                 continue
 
             token_indexes = flat_token[s_i:e_i]
@@ -305,7 +329,7 @@ class TransformerBlock(nn.Module):
         self.attention_norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.ffn_norm = RMSNorm(config.dim, eps=config.norm_eps)
 
-    def forward(self, x, rope_freqs, mask=None, layer_k_cache=None, layer_v_cache=None, start_position: int = 0):
+    def forward(self, x, rope_freqs, mask=None, router_loss_mask=None, layer_k_cache=None, layer_v_cache=None, start_position: int = 0):
         hidden_state = x + self.attention(
             self.attention_norm(x),
             rope_freqs,
@@ -314,7 +338,10 @@ class TransformerBlock(nn.Module):
             layer_v_cache=layer_v_cache,
             start_position=start_position
         )
-        ff, aux = self.feed_forward(self.ffn_norm(hidden_state))
+        ff, aux = self.feed_forward(
+            self.ffn_norm(hidden_state),
+            router_loss_mask
+        )
         output = hidden_state + ff
         return output, aux
 
@@ -486,6 +513,11 @@ class TendrilMoETransformer(BaseModel):
                     causal_keep = (k_pos[None, :] <= q_pos[:, None])[None, None, :, :]  # (1,1,Q,K)
                     attn_mask = attn_mask.expand(attn_mask.size(0), 1, sequence_length, k_length) & causal_keep
 
+        router_loss_mask = None
+        if labels is not None:
+            labels = labels.to(hidden_state.device)
+            router_loss_mask = labels != self.ignore_index
+
         aux_loss_total = hidden_state.new_zeros(())
         for layer_id, layer in enumerate(self.layers):
             layer_k_cache = None
@@ -498,6 +530,7 @@ class TendrilMoETransformer(BaseModel):
                 hidden_state,
                 rope_freqs,
                 attn_mask,
+                router_loss_mask,
                 layer_k_cache=layer_k_cache,
                 layer_v_cache=layer_v_cache,
                 start_position=start_position
@@ -515,7 +548,11 @@ class TendrilMoETransformer(BaseModel):
                 labels = labels.to(hidden_state.device)
             flat_logits = logits.view(-1, logits.size(-1))  # (batch_size * sequence_length, num_classes)
             flat_labels = labels.view(-1)  # (batch_size * sequence_length)
-            ce = nn.CrossEntropyLoss(ignore_index=self.ignore_index)(flat_logits, flat_labels)
-            loss = ce + (aux_loss_total / self.n_layers)
+            loss = nn.CrossEntropyLoss(ignore_index=self.ignore_index)(flat_logits, flat_labels)
 
-        return {'logits': logits, 'loss': loss, 'kv_cache': kv_cache}
+        return {
+            'logits': logits,
+            'loss': loss,
+            'aux_loss': aux_loss_total / self.n_layers,
+            'kv_cache': kv_cache
+        }

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -73,6 +73,8 @@ class CausalTask(BaseTask):
         }
 
         n_valid = (y != ignore_index).sum()
+        if n_valid.item() == 0:
+            raise ValueError('Causal batch has no valid supervised tokens')
 
         if self.config.distillation.enabled:
             tokens_processed += x.numel()

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -80,7 +80,7 @@ class CausalTask(BaseTask):
             tokens_processed += x.numel()
 
             with torch.no_grad():
-                teacher_logits = assets.teacher_model(input_ids=x, )['logits']
+                teacher_logits = assets.teacher_model(input_ids=x, attention_mask=attention_mask)['logits']
 
             valid_mask = y != ignore_index
 

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -48,6 +48,7 @@ class CausalTask(BaseTask):
         device_type = self.ctx.device.device_type
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
+        ignore_index = self.config.tokenizer.ignore_index
 
         x, y, attention_mask = batch
         x = x.to(device, non_blocking=True)
@@ -71,23 +72,26 @@ class CausalTask(BaseTask):
             'Train Loss': loss.detach()
         }
 
+        n_valid = (y != ignore_index).sum()
+
         if self.config.distillation.enabled:
             tokens_processed += x.numel()
 
             with torch.no_grad():
-                teacher_logits = assets.teacher_model(input_ids=x)['logits']
+                teacher_logits = assets.teacher_model(input_ids=x, )['logits']
+
+            valid_mask = y != ignore_index
 
             loss_distil = distillation_loss(
                 teacher_logits,
                 result['logits'],
-                temperature=self.config.distillation.temperature
+                temperature=self.config.distillation.temperature,
+                valid_mask=valid_mask
             )
             loss_for_backward = loss_for_backward + loss_distil
 
             metrics['Train Loss'] = loss_for_backward.detach()
             metrics['Train Distill Loss'] = loss_distil.detach()
-
-        n_valid = (y != self.config.tokenizer.ignore_index).sum()
 
         loss_for_backward = loss_for_backward * n_valid
 

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -48,7 +48,6 @@ class CausalTask(BaseTask):
         device_type = self.ctx.device.device_type
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
-        grad_accum_steps = self.ctx.grad_accum_steps
 
         x, y, attention_mask = batch
         x = x.to(device, non_blocking=True)
@@ -88,9 +87,9 @@ class CausalTask(BaseTask):
             metrics['Train Loss'] = loss_for_backward.detach()
             metrics['Train Distill Loss'] = loss_distil.detach()
 
-        loss_for_backward = loss_for_backward / grad_accum_steps
-
         n_valid = (y != self.config.tokenizer.ignore_index).sum()
+
+        loss_for_backward = loss_for_backward * n_valid
 
         return TaskStepOutput(
             tokens_processed=tokens_processed,

--- a/tasks/causal.py
+++ b/tasks/causal.py
@@ -53,6 +53,11 @@ class CausalTask(BaseTask):
         x, y, attention_mask = batch
         x = x.to(device, non_blocking=True)
         y = y.to(device, non_blocking=True)
+
+        n_valid = (y != ignore_index).sum()
+        if n_valid.item() == 0:
+            raise ValueError('Causal batch has no valid supervised tokens')
+
         if attention_mask is not None:
             attention_mask = attention_mask.to(device, non_blocking=True)
 
@@ -64,17 +69,20 @@ class CausalTask(BaseTask):
             enabled=use_autocast
         ):
             result = model(x, labels=y, attention_mask=attention_mask)
-            loss = result['loss']
+            ce_loss = result['loss']
+            aux_loss = result.get('aux_loss')
 
-        loss_for_backward = loss
+            objective_loss = ce_loss
+            if aux_loss is not None:
+                objective_loss = objective_loss + aux_loss
 
         metrics = {
-            'Train Loss': loss.detach()
+            'Train Loss': objective_loss.detach(),
+            'Train CE Loss': ce_loss.detach(),
         }
 
-        n_valid = (y != ignore_index).sum()
-        if n_valid.item() == 0:
-            raise ValueError('Causal batch has no valid supervised tokens')
+        if aux_loss is not None:
+            metrics['Train Aux Loss'] = aux_loss.detach()
 
         if self.config.distillation.enabled:
             tokens_processed += x.numel()
@@ -90,17 +98,17 @@ class CausalTask(BaseTask):
                 temperature=self.config.distillation.temperature,
                 valid_mask=valid_mask
             )
-            loss_for_backward = loss_for_backward + loss_distil
+            objective_loss = objective_loss + loss_distil
 
-            metrics['Train Loss'] = loss_for_backward.detach()
+            metrics['Train Loss'] = objective_loss.detach()
             metrics['Train Distill Loss'] = loss_distil.detach()
 
-        loss_for_backward = loss_for_backward * n_valid
+        loss_for_backward = objective_loss * n_valid
 
         return TaskStepOutput(
             tokens_processed=tokens_processed,
             n_valid=n_valid,
-            loss=loss,
+            loss=objective_loss,
             loss_for_backward=loss_for_backward,
             metrics=metrics
         )
@@ -111,19 +119,39 @@ class CausalTask(BaseTask):
         device_type = self.ctx.device.device_type
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
+        ignore_index = self.config.tokenizer.ignore_index
 
         x, y, attention_mask = batch
         x = x.to(device, non_blocking=True)
         y = y.to(device, non_blocking=True)
+
+        n_valid = (y != ignore_index).sum().float()
+        if n_valid.item() == 0:
+            raise ValueError(
+                'Causal validation batch has no valid supervised tokens'
+            )
+
         if attention_mask is not None:
             attention_mask = attention_mask.to(device, non_blocking=True)
 
         with torch.autocast(device_type=device_type, dtype=autocast_dtype, enabled=use_autocast):
-            loss = model(x, labels=y, attention_mask=attention_mask)['loss']
-        
-        n_valid = (y != self.config.tokenizer.ignore_index).sum().float()
+            result = model(x, labels=y, attention_mask=attention_mask)
+            ce_loss = result['loss']
+            aux_loss = result.get('aux_loss')
+
+            objective_loss = ce_loss
+            if aux_loss is not None:
+                objective_loss = objective_loss + aux_loss
+
+        metrics = {
+            'Val CE Loss': ce_loss.detach(),
+        }
+
+        if aux_loss is not None:
+            metrics['Val Aux Loss'] = aux_loss.detach()
 
         return TaskStepOutput(
             n_valid=n_valid,
-            loss=loss
+            loss=objective_loss,
+            metrics=metrics
         )

--- a/tasks/distillation_utils.py
+++ b/tasks/distillation_utils.py
@@ -2,9 +2,16 @@ import torch
 import torch.nn.functional as F
 
 
-def distillation_loss(teacher_logits, student_logits, temperature=1.0):
+def distillation_loss(teacher_logits, student_logits, temperature=2.0, valid_mask=None):
     teacher_probabilities = F.softmax(teacher_logits.view(-1, teacher_logits.size(-1)) / temperature, dim=-1)
     student_log_probabilities = F.log_softmax(student_logits.view(-1, student_logits.size(-1)) / temperature, dim=-1)
 
-    kl_divergence = F.kl_div(student_log_probabilities, teacher_probabilities, reduction='batchmean') * (temperature ** 2)
-    return kl_divergence
+    kl_divergence_per_token = F.kl_div(student_log_probabilities, teacher_probabilities, reduction='none').sum(dim=-1) * (temperature ** 2)
+    kl_divergence_per_token_sum = kl_divergence_per_token.sum()
+
+    if valid_mask is not None:
+        valid_mask = valid_mask.reshape(-1).to(dtype=kl_divergence_per_token.dtype)
+        kl_divergence_per_token = kl_divergence_per_token * valid_mask
+        return kl_divergence_per_token_sum / valid_mask.sum().clamp_min(1.0)
+
+    return kl_divergence_per_token_sum / torch.tensor(kl_divergence_per_token.numel(), dtype=kl_divergence_per_token.dtype)

--- a/tasks/distillation_utils.py
+++ b/tasks/distillation_utils.py
@@ -7,11 +7,10 @@ def distillation_loss(teacher_logits, student_logits, temperature=2.0, valid_mas
     student_log_probabilities = F.log_softmax(student_logits.view(-1, student_logits.size(-1)) / temperature, dim=-1)
 
     kl_divergence_per_token = F.kl_div(student_log_probabilities, teacher_probabilities, reduction='none').sum(dim=-1) * (temperature ** 2)
-    kl_divergence_per_token_sum = kl_divergence_per_token.sum()
 
     if valid_mask is not None:
         valid_mask = valid_mask.reshape(-1).to(dtype=kl_divergence_per_token.dtype)
         kl_divergence_per_token = kl_divergence_per_token * valid_mask
-        return kl_divergence_per_token_sum / valid_mask.sum().clamp_min(1.0)
+        return kl_divergence_per_token.sum() / valid_mask.sum().clamp_min(1.0)
 
-    return kl_divergence_per_token_sum / torch.tensor(kl_divergence_per_token.numel(), dtype=kl_divergence_per_token.dtype)
+    return kl_divergence_per_token.sum() / torch.tensor(kl_divergence_per_token.numel(), dtype=kl_divergence_per_token.dtype)

--- a/tasks/distillation_utils.py
+++ b/tasks/distillation_utils.py
@@ -3,8 +3,8 @@ import torch.nn.functional as F
 
 
 def distillation_loss(teacher_logits, student_logits, temperature=2.0, valid_mask=None):
-    teacher_probabilities = F.softmax(teacher_logits.view(-1, teacher_logits.size(-1)) / temperature, dim=-1)
-    student_log_probabilities = F.log_softmax(student_logits.view(-1, student_logits.size(-1)) / temperature, dim=-1)
+    teacher_probabilities = F.softmax(teacher_logits.reshape(-1, teacher_logits.size(-1)) / temperature, dim=-1)
+    student_log_probabilities = F.log_softmax(student_logits.reshape(-1, student_logits.size(-1)) / temperature, dim=-1)
 
     kl_divergence_per_token = F.kl_div(student_log_probabilities, teacher_probabilities, reduction='none').sum(dim=-1) * (temperature ** 2)
 

--- a/tasks/dpo.py
+++ b/tasks/dpo.py
@@ -47,7 +47,6 @@ class DPOTask(BaseTask):
         device_type = self.ctx.device.device_type
         autocast_dtype = self.ctx.precision.autocast_dtype
         use_autocast = self.ctx.precision.use_autocast
-        grad_accum_steps = self.ctx.grad_accum_steps
         dpo_beta = self.config.dpo.beta
         ignore_index = self.config.tokenizer.ignore_index
 
@@ -89,13 +88,13 @@ class DPOTask(BaseTask):
             dpo_beta
         )
 
-        loss_for_backward = loss / grad_accum_steps
-
         n_valid = torch.tensor(
             chosen_input_ids.size(0),
             device=device,
             dtype=loss.dtype
         )
+
+        loss_for_backward = loss * n_valid
 
         return TaskStepOutput(
             tokens_processed=tokens_processed,

--- a/tests/test_moe_aux_loss.py
+++ b/tests/test_moe_aux_loss.py
@@ -75,10 +75,3 @@ def test_moe_router_loss_mask_only_changes_auxiliary_loss():
     assert not torch.isclose(aux_loss_supervised, aux_loss_all)
 
     torch.testing.assert_close(aux_loss_all, torch.tensor(1.0))
-
-    expected_supervised_aux_loss = 2.0 * torch.stack(
-        [
-            aux_loss_supervised.new_tensor(4.0).sigmoid(),
-            aux_loss_supervised.new_tensor(2.0).sigmoid(),
-        ]
-    ).mean()

--- a/tests/test_moe_aux_loss.py
+++ b/tests/test_moe_aux_loss.py
@@ -73,3 +73,12 @@ def test_moe_router_loss_mask_only_changes_auxiliary_loss():
     # The auxiliary population changed from balanced routing over all tokens to
     # only the two tokens routed to expert 0, so the auxiliary loss must change.
     assert not torch.isclose(aux_loss_supervised, aux_loss_all)
+
+    torch.testing.assert_close(aux_loss_all, torch.tensor(1.0))
+
+    expected_supervised_aux_loss = 2.0 * torch.stack(
+        [
+            aux_loss_supervised.new_tensor(4.0).sigmoid(),
+            aux_loss_supervised.new_tensor(2.0).sigmoid(),
+        ]
+    ).mean()

--- a/tests/test_moe_aux_loss.py
+++ b/tests/test_moe_aux_loss.py
@@ -1,0 +1,75 @@
+import torch
+
+from models.implementations.tendril_moe import MoEFeedForward
+
+
+def _build_deterministic_moe() -> MoEFeedForward:
+    moe = MoEFeedForward(
+        dim=2,
+        hidden_dim=4,
+        multiple_of=1,
+        ffn_dim_multiplier=None,
+        num_experts=2,
+        expert_dim=2,
+        top_k=1,
+        load_balancing_coef=1.0,
+        z_loss_coef=0.0,
+    )
+
+    with torch.no_grad():
+        # Positive first coordinates route to expert 0; negative ones to expert 1.
+        moe.router.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0],
+                    [-1.0, 0.0],
+                ]
+            )
+        )
+
+        # Make every expert deterministic and ensure every routed token receives
+        # a non-zero feed-forward output.
+        identity = torch.eye(2)
+        for expert in moe.experts:
+            expert.w1.weight.copy_(identity)
+            expert.w2.weight.copy_(identity)
+            expert.w3.weight.copy_(identity)
+
+    return moe
+
+
+def test_moe_router_loss_mask_only_changes_auxiliary_loss():
+    """
+    The supervised-token mask must affect router auxiliary statistics only.
+
+    Every token must still be routed through an expert, including tokens that
+    are excluded from the auxiliary objective.
+    """
+    moe = _build_deterministic_moe()
+
+    x = torch.tensor(
+        [
+            [
+                [2.0, 1.0],
+                [1.0, 1.0],
+                [-1.0, 1.0],
+                [-2.0, 1.0],
+            ]
+        ]
+    )
+
+    all_tokens_mask = torch.ones((1, 4), dtype=torch.bool)
+    supervised_tokens_mask = torch.tensor([[True, True, False, False]], dtype=torch.bool)
+
+    output_all, aux_loss_all = moe(x, router_loss_mask=all_tokens_mask)
+    output_supervised, aux_loss_supervised = moe(x, router_loss_mask=supervised_tokens_mask)
+
+    # The mask must not change actual expert routing or model activations.
+    torch.testing.assert_close(output_supervised, output_all)
+
+    # The masked-out tokens must still have passed through their experts.
+    assert torch.count_nonzero(output_supervised[:, 2:]).item() > 0
+
+    # The auxiliary population changed from balanced routing over all tokens to
+    # only the two tokens routed to expert 0, so the auxiliary loss must change.
+    assert not torch.isclose(aux_loss_supervised, aux_loss_all)

--- a/tests/test_post_training_loss_scaling.py
+++ b/tests/test_post_training_loss_scaling.py
@@ -1,0 +1,87 @@
+import torch
+
+from types import SimpleNamespace
+from torch import nn
+from engine.trainer import Trainer
+
+
+def _build_trainer_for_gradient_scaling(model: nn.Module, world_size: int) -> Trainer:
+    """Build only the Trainer state required by scale_gradients_by_n_valid."""
+    trainer = object.__new__(Trainer)
+    trainer.model = model
+    trainer.trainer_ctx = SimpleNamespace(
+        distributed=SimpleNamespace(ddp_world_size=world_size)
+    )
+    return trainer
+
+def test_unequal_n_valid_microbatches_use_global_token_mean():
+    """
+    Two microbatches contain 1 and 3 valid tokens.
+
+    The correct gradient is the mean over all four valid tokens:
+        (1 + 3 + 5 + 7) / 4 = 4
+
+    Equal averaging of the two microbatch means would incorrectly produce:
+        (1 + 5) / 2 = 3
+    """
+    parameter = nn.Parameter(torch.tensor(2.0))
+    model = nn.Module()
+    model.register_parameter('weight', parameter)
+
+    trainer = _build_trainer_for_gradient_scaling(model, world_size=1)
+
+    microbatch_token_coefficients = (
+        torch.tensor([1.0]),
+        torch.tensor([3.0, 5.0, 7.0]),
+    )
+
+    n_valid_sum = torch.zeros(())
+
+    for coefficients in microbatch_token_coefficients:
+        # This represents a task returning a summed objective numerator.
+        loss_for_backward = (parameter * coefficients).sum()
+        loss_for_backward.backward()
+        n_valid_sum += coefficients.numel()
+
+    grad_scale = trainer.scale_gradients_by_n_valid(n_valid_sum)
+
+    torch.testing.assert_close(torch.tensor(grad_scale), torch.tensor(1.0 / 4.0))
+    torch.testing.assert_close(parameter.grad, torch.tensor(4.0))
+
+    incorrect_equal_microbatch_mean = torch.tensor(3.0)
+    assert not torch.isclose(parameter.grad, incorrect_equal_microbatch_mean)
+
+
+def test_scale_gradients_by_n_valid_accounts_for_ddp_gradient_averaging():
+    """
+    Simulate two DDP ranks.
+
+    Rank-local summed gradients:
+        rank 0: gradient=6, n_valid=2
+        rank 1: gradient=12, n_valid=6
+
+    DDP first averages the gradients:
+        (6 + 12) / 2 = 9
+
+    The production helper must then multiply by:
+        world_size / global_n_valid = 2 / 8
+
+    producing the global mean gradient:
+        9 * (2 / 8) = (6 + 12) / 8 = 2.25
+    """
+    model = nn.Linear(1, 1, bias=False)
+    parameter = model.weight
+
+    ddp_averaged_gradient = torch.tensor([[9.0]])
+    parameter.grad = ddp_averaged_gradient.clone()
+
+    trainer = _build_trainer_for_gradient_scaling(model, world_size=2)
+
+    global_n_valid = torch.tensor(8.0)
+    grad_scale = trainer.scale_gradients_by_n_valid(global_n_valid)
+
+    expected_scale = torch.tensor(2.0 / 8.0)
+    expected_global_mean_gradient = torch.tensor([[(6.0 + 12.0) / (2.0 + 6.0)]])
+
+    torch.testing.assert_close(torch.tensor(grad_scale), expected_scale)
+    torch.testing.assert_close(parameter.grad, expected_global_mean_gradient)


### PR DESCRIPTION
At the moment we naively scale the loss inside the task by the gradient accumulation steps which is the naive approach (as it assumes all sequences are same size and valid). This works well for pretraining but for stages where sequences can have different sizes and we must only calculate the loss in supervised tokens, this doesn't work very well and causes noisy gradients.

Changes:
- New approach is to instead always track the number of valid tokens per rank, calculate the total after processing the microbatches and then scale the accumulated gradients by the number of valid tokens (compatible with all stages). DDP(including FSDP) already in theory scales the gradients by the number of ranks, so we just need to multiple by number of ranks / number of valid tokens.
- Updated MoE architecture so the aux loss depends only on the n_valid tokens.
- Added tests for moe aux loss and the loss scaling.