### PR TITLE
Fix and improvements for multiturn sft/dpo encoding

### DIFF
--- a/datasets_preparation/prepare_dpo_dataset.py
+++ b/datasets_preparation/prepare_dpo_dataset.py
@@ -59,11 +59,28 @@ SUPPORTED_HF_DATASETS = {
     }
 }
 
-def remove_system_messages(conversation):
-    return [
-        message for message in conversation
-        if message['role'] != 'system'
-    ]
+def extract_leading_system_prompt(conversation):
+    system_parts = []
+    remaining = []
+    seen_non_system = False
+
+    for message in conversation:
+        role = message['role']
+        content = message['content'].strip()
+
+        if role == 'system':
+            if seen_non_system:
+                return '', []
+            if content:
+                system_parts.append(content)
+            continue
+
+        seen_non_system = True
+        remaining.append(message)
+
+    system_prompt = '\n\n'.join(system_parts)
+
+    return system_prompt or '', remaining
 
 def ensure_only_user_assistant(conversation):
     allowed_roles = {'user', 'assistant'}
@@ -111,12 +128,26 @@ def ensure_alternating_prompt_for_dpo(conversation):
 
     return conversation
 
+def ensure_nonempty_content(conversation):
+    for message in conversation:
+        content = message.get('content')
+
+        if not isinstance(content, str):
+            return []
+
+        if not content.strip():
+            return []
+
+    return conversation
+
 tokenizer = None
 
 def tokenize(tokenizer_kwargs, ignore_index, max_seq_len, doc):
     global tokenizer
     if tokenizer is None:
         tokenizer = init_tokenizer(**tokenizer_kwargs)
+
+    source_system_prompt = doc.get('system_prompt', '').strip() or None
 
     (
         prompt_input_ids,
@@ -129,6 +160,7 @@ def tokenize(tokenizer_kwargs, ignore_index, max_seq_len, doc):
         chosen=doc['chosen'],
         rejected=doc['rejected'],
         ignore_index=ignore_index,
+        system_prompt=source_system_prompt,
         max_seq_len=max_seq_len,
         trim_to_context=True
     )
@@ -190,12 +222,16 @@ def download_and_prepare_data(
             data = adapter(doc, transforms)
 
             prompt = data['prompt']
-            prompt = remove_system_messages(prompt)
+
+            source_system_prompt, prompt = extract_leading_system_prompt(prompt)
+
             prompt = ensure_only_user_assistant(prompt)
             prompt = ensure_user_first(prompt)
             prompt = ensure_user_last(prompt)
             prompt = ensure_alternating_prompt_for_dpo(prompt)
+            prompt = ensure_nonempty_content(prompt)
 
+            data['system_prompt'] = source_system_prompt
             data['prompt'] = prompt
             data['chosen'] = data['chosen'].strip()
             data['rejected'] = data['rejected'].strip()

--- a/datasets_preparation/prepare_instruct_dataset.py
+++ b/datasets_preparation/prepare_instruct_dataset.py
@@ -117,11 +117,28 @@ SUPPORTED_LOCAL_DATASETS = {
     }
 }
 
-def remove_system_messages(conversation):
-    return [
-        message for message in conversation
-        if message['role'] != 'system'
-    ]
+def extract_leading_system_prompt(conversation):
+    system_parts = []
+    remaining = []
+    seen_non_system = False
+
+    for message in conversation:
+        role = message['role']
+        content = message['content'].strip()
+
+        if role == 'system':
+            if seen_non_system:
+                return '', []
+            if content:
+                system_parts.append(content)
+            continue
+
+        seen_non_system = True
+        remaining.append(message)
+
+    system_prompt = '\n\n'.join(system_parts)
+
+    return system_prompt or '', remaining
 
 def ensure_only_user_assistant(conversation):
     allowed_roles = {'user', 'assistant'}
@@ -162,6 +179,18 @@ def ensure_alternating_user_assistant(conversation):
 
     return conversation
 
+def ensure_nonempty_content(conversation):
+    for message in conversation:
+        content = message.get('content')
+
+        if not isinstance(content, str):
+            return []
+
+        if not content.strip():
+            return []
+
+    return conversation
+
 tokenizer = None
 
 def tokenize(tokenizer_kwargs, ignore_index, max_seq_len, doc):
@@ -169,9 +198,12 @@ def tokenize(tokenizer_kwargs, ignore_index, max_seq_len, doc):
     if tokenizer is None:
         tokenizer = init_tokenizer(**tokenizer_kwargs)
 
+    source_system_prompt = doc.get('system_prompt', '').strip() or None
+
     tokens, labels = tokenizer.encode_instruct_chat(
         conversation=doc['conversation'],
         ignore_index=ignore_index,
+        system_prompt=source_system_prompt,
         max_seq_len=max_seq_len,
         trim_to_context=True
     )
@@ -247,13 +279,17 @@ def download_and_prepare_data(
 
         def normalize(doc):
             conversation = adapter(doc, transforms, seed)
-            conversation = remove_system_messages(conversation)
+
+            source_system_prompt, conversation = extract_leading_system_prompt(conversation)
+
             conversation = ensure_only_user_assistant(conversation)
             conversation = ensure_user_first(conversation)
             conversation = trim_to_last_assistant(conversation)
             conversation = ensure_alternating_user_assistant(conversation)
+            conversation = ensure_nonempty_content(conversation)
 
             return {
+                'system_prompt': source_system_prompt,
                 'conversation': conversation,
                 'source': source_key
             }

--- a/gradio_serve.py
+++ b/gradio_serve.py
@@ -44,13 +44,12 @@ class UI:
         temperature: float,
         top_p: float,
     ) -> str:
-            if self.debug:
-                logger.info(f'HISTORY: {history}')
-                logger.info(f'MESSAGE: {message}')
-            
             messages = [{'role': 'system', 'content': system_prompt}]
             messages.extend(self.normalize_history(history))
             messages.append({'role': 'user', 'content': message})
+
+            if self.debug:
+                logger.info(f'CONTEXT: {messages}')
 
             outputs = self.inspector.generate(
                 [messages],
@@ -64,7 +63,11 @@ class UI:
                 prompts_are_messages=True,
             )
 
-            return outputs[0]['result_decoded']
+            answer = outputs[0]['result_decoded']
+            if self.debug:
+                logger.info(f'ANSWER: {answer}\n')
+
+            return answer
 
     def init_ui(self, *, server_name='localhost', server_port=6006, share=False):
         logger.set_master(True)

--- a/models/implementations/tendril.py
+++ b/models/implementations/tendril.py
@@ -12,9 +12,9 @@ def precompute_rope_freqs(head_dim, sequence_length, theta=10000.0, device='cpu'
     ''' Computes the frequencies that will be used for rope (rotary positional ebedding). Without complex numbers.
     '''
     indices = torch.arange(0, head_dim // 2, device=device, dtype=torch.float32)
-    normalised_indices = 2.0 * indices / head_dim
+    normalized_indices = 2.0 * indices / head_dim
 
-    freqs = 1.0 / (theta ** normalised_indices)
+    freqs = 1.0 / (theta ** normalized_indices)
 
     timesteps = torch.arange(sequence_length, device=device, dtype=torch.float32)
 
@@ -313,6 +313,8 @@ class TendrilTransformer(BaseModel):
                     k_pos = torch.arange(0, k_length, device=hidden_state.device)
                     causal_keep = (k_pos[None, :] <= q_pos[:, None])[None, None, :, :]  # (1,1,Q,K)
                     attn_mask = attn_mask.expand(attn_mask.size(0), 1, sequence_length, k_length) & causal_keep
+
+                attn_mask = attn_mask.contiguous()
 
         for layer_id, layer in enumerate(self.layers):
             layer_k_cache = None

--- a/models/implementations/tendril_moe.py
+++ b/models/implementations/tendril_moe.py
@@ -16,9 +16,9 @@ def precompute_rope_freqs(head_dim, sequence_length, theta=10000.0, device='cpu'
     ''' Computes the frequencies that will be used for rope (rotary positional ebedding). Without complex numbers.
     '''
     indices = torch.arange(0, head_dim // 2, device=device, dtype=torch.float32)
-    normalised_indices = 2.0 * indices / head_dim
+    normalized_indices = 2.0 * indices / head_dim
 
-    freqs = 1.0 / (theta ** normalised_indices)
+    freqs = 1.0 / (theta ** normalized_indices)
 
     timesteps = torch.arange(sequence_length, device=device, dtype=torch.float32)
 
@@ -512,6 +512,8 @@ class TendrilMoETransformer(BaseModel):
                     k_pos = torch.arange(0, k_length, device=hidden_state.device)
                     causal_keep = (k_pos[None, :] <= q_pos[:, None])[None, None, :, :]  # (1,1,Q,K)
                     attn_mask = attn_mask.expand(attn_mask.size(0), 1, sequence_length, k_length) & causal_keep
+
+                attn_mask = attn_mask.contiguous()
 
         router_loss_mask = None
         if labels is not None:

--- a/tests/test_dpo_encoding.py
+++ b/tests/test_dpo_encoding.py
@@ -1,0 +1,114 @@
+import pytest
+
+
+IGNORE_INDEX = -100
+
+def supervised_ids(labels):
+    return [
+        int(token_id)
+        for token_id in labels
+        if int(token_id) != IGNORE_INDEX
+    ]
+
+def contains_subsequence(sequence, subsequence):
+    if not subsequence:
+        return True
+
+    width = len(subsequence)
+
+    return any(sequence[index:index + width] == subsequence for index in range(len(sequence) - width + 1))
+
+def test_dpo_history_boundaries_and_answer_supervision(tokenizer):
+    conversation = [
+        {'role': 'user', 'content': 'U1'},
+        {'role': 'assistant', 'content': 'A1'},
+        {'role': 'user', 'content': 'U2'},
+    ]
+
+    (
+        prompt_ids,
+        chosen_ids,
+        chosen_labels,
+        rejected_ids,
+        rejected_labels,
+    ) = tokenizer.encode_instruct_chat_dpo(
+        conversation=conversation,
+        chosen='Chosen answer',
+        rejected='Rejected answer',
+        system_prompt='Preference policy',
+        ignore_index=IGNORE_INDEX,
+    )
+
+    expected_history_boundary = (
+        tokenizer.encode('Assistant: ')
+        + tokenizer.encode('A1')
+        + [tokenizer.eos_id]
+        + tokenizer.encode('User: ')
+        + tokenizer.encode('U2\n')
+        + tokenizer.encode('Assistant: ')
+    )
+
+    assert contains_subsequence(prompt_ids, expected_history_boundary)
+
+    assert supervised_ids(chosen_labels) == (
+        tokenizer.encode('Chosen answer')
+        + [tokenizer.eos_id]
+    )
+
+    assert supervised_ids(rejected_labels) == (
+        tokenizer.encode('Rejected answer')
+        + [tokenizer.eos_id]
+    )
+
+    assert chosen_ids == (
+        prompt_ids
+        + tokenizer.encode('Chosen answer')
+        + [tokenizer.eos_id]
+    )
+
+    assert rejected_ids == (
+        prompt_ids
+        + tokenizer.encode('Rejected answer')
+        + [tokenizer.eos_id]
+    )
+
+@pytest.mark.parametrize(
+    'conversation, expected_error',
+    [
+        (
+            [
+                {'role': 'user', 'content': 'Question'},
+                {'role': 'assistant', 'content': 'Wrong final role'},
+            ],
+            'must end with user',
+        ),
+        (
+            [
+                {'role': 'assistant', 'content': 'Unexpected'},
+                {'role': 'user', 'content': 'Question'},
+            ],
+            'Expected user',
+        ),
+        (
+            [
+                {'role': 'user', 'content': 'U1'},
+                {'role': 'user', 'content': 'U2'},
+            ],
+            'Expected assistant',
+        ),
+    ],
+)
+def test_dpo_validation_runs_before_trimming(
+    tokenizer,
+    conversation,
+    expected_error,
+):
+    with pytest.raises(ValueError, match=expected_error):
+        tokenizer.encode_instruct_chat_dpo(
+            conversation=conversation,
+            chosen='Chosen',
+            rejected='Rejected',
+            ignore_index=IGNORE_INDEX,
+            max_seq_len=10_000,
+            trim_to_context=True,
+        )

--- a/tests/test_sft_encoding.py
+++ b/tests/test_sft_encoding.py
@@ -1,0 +1,195 @@
+import pytest
+
+
+IGNORE_INDEX = -100
+
+def supervised_ids(labels):
+    return [
+        int(token_id)
+        for token_id in labels
+        if int(token_id) != IGNORE_INDEX
+    ]
+
+def contains_subsequence(sequence, subsequence):
+    if not subsequence:
+        return True
+
+    width = len(subsequence)
+
+    return any(sequence[index:index + width] == subsequence for index in range(len(sequence) - width + 1))
+
+def test_sft_supervises_every_assistant_turn_and_eos(tokenizer):
+    conversation = [
+        {'role': 'user', 'content': 'U1'},
+        {'role': 'assistant', 'content': 'A1'},
+        {'role': 'user', 'content': 'U2'},
+        {'role': 'assistant', 'content': 'A2'},
+    ]
+
+    tokens, labels = tokenizer.encode_instruct_chat(
+        conversation=conversation,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    expected_supervised = (
+        tokenizer.encode('A1')
+        + [tokenizer.eos_id]
+        + tokenizer.encode('A2')
+        + [tokenizer.eos_id]
+    )
+
+    assert len(tokens) == len(labels)
+    assert supervised_ids(labels) == expected_supervised
+
+    # Exclude BOS because some tokenizers use the same ID for BOS and EOS.
+    assert tokens[1:].count(tokenizer.eos_id) == 2
+
+def test_sft_source_system_prompt_overrides_default(tokenizer):
+    source_system_prompt = 'Rewrite the input concisely.'
+
+    tokens, _ = tokenizer.encode_instruct_chat(
+        system_prompt=source_system_prompt,
+        conversation=[
+            {'role': 'user', 'content': 'Long input'},
+            {'role': 'assistant', 'content': 'Short output'},
+        ],
+        ignore_index=IGNORE_INDEX,
+    )
+
+    expected_prefix = (
+        [tokenizer.bos_id]
+        + tokenizer.encode('System: ')
+        + tokenizer.encode(source_system_prompt + '\n')
+    )
+
+    assert tokens[:len(expected_prefix)] == expected_prefix
+
+    decoded = tokenizer.decode(tokens)
+    assert source_system_prompt in decoded
+    assert tokenizer.system_prompt not in decoded
+
+def test_sft_none_system_prompt_uses_default(tokenizer):
+    tokens, _ = tokenizer.encode_instruct_chat(
+        system_prompt=None,
+        conversation=[
+            {'role': 'user', 'content': 'Question'},
+            {'role': 'assistant', 'content': 'Answer'},
+        ],
+        ignore_index=IGNORE_INDEX,
+    )
+
+    expected_prefix = (
+        [tokenizer.bos_id]
+        + tokenizer.encode('System: ')
+        + tokenizer.encode(tokenizer.system_prompt + '\n')
+    )
+
+    assert tokens[:len(expected_prefix)] == expected_prefix
+
+def test_inference_history_uses_eos_after_assistant_turn(tokenizer):
+    tokens = tokenizer.encode_instruct_messages_inference([
+        {'role': 'system', 'content': 'System instruction'},
+        {'role': 'user', 'content': 'First question'},
+        {'role': 'assistant', 'content': 'First answer'},
+        {'role': 'user', 'content': 'Second question'},
+    ])
+
+    expected_boundary = (
+        tokenizer.encode('Assistant: ')
+        + tokenizer.encode('First answer')
+        + [tokenizer.eos_id]
+        + tokenizer.encode('User: ')
+        + tokenizer.encode('Second question\n')
+        + tokenizer.encode('Assistant: ')
+    )
+
+    assert contains_subsequence(tokens, expected_boundary)
+
+@pytest.mark.parametrize(
+    'conversation, expected_error',
+    [
+        (
+            [{'role': 'assistant', 'content': 'Unexpected'}],
+            'Expected user',
+        ),
+        (
+            [{'role': 'user', 'content': 'Missing answer'}],
+            'must end with assistant',
+        ),
+        (
+            [
+                {'role': 'system', 'content': 'Unexpected system'},
+                {'role': 'assistant', 'content': 'Answer'},
+            ],
+            'Unexpected role',
+        ),
+        (
+            [
+                {'role': 'user', 'content': 'U1'},
+                {'role': 'user', 'content': 'U2'},
+                {'role': 'assistant', 'content': 'A2'},
+            ],
+            'Expected assistant',
+        ),
+    ],
+)
+def test_sft_validation_runs_before_trimming(
+    tokenizer,
+    conversation,
+    expected_error,
+):
+    with pytest.raises(ValueError, match=expected_error):
+        tokenizer.encode_instruct_chat(
+            conversation=conversation,
+            ignore_index=IGNORE_INDEX,
+            max_seq_len=10_000,
+            trim_to_context=True,
+        )
+
+def test_sft_trimming_keeps_newest_complete_pairs(tokenizer):
+    conversation = [
+        {'role': 'user', 'content': 'Old user'},
+        {'role': 'assistant', 'content': 'Old assistant'},
+        {'role': 'user', 'content': 'Middle user'},
+        {'role': 'assistant', 'content': 'Middle assistant'},
+        {'role': 'user', 'content': 'Latest user'},
+        {'role': 'assistant', 'content': 'Latest assistant'},
+    ]
+
+    expected_tokens, expected_labels = tokenizer.encode_instruct_chat(
+        conversation=conversation[-4:],
+        ignore_index=IGNORE_INDEX,
+    )
+
+    tokens, labels = tokenizer.encode_instruct_chat(
+        conversation=conversation,
+        ignore_index=IGNORE_INDEX,
+        max_seq_len=len(expected_tokens),
+        trim_to_context=True,
+    )
+
+    assert tokens == expected_tokens
+    assert labels == expected_labels
+
+    decoded = tokenizer.decode(tokens)
+
+    assert 'Old user' not in decoded
+    assert 'Old assistant' not in decoded
+    assert 'Middle user' in decoded
+    assert 'Middle assistant' in decoded
+    assert 'Latest user' in decoded
+    assert 'Latest assistant' in decoded
+
+def test_sft_returns_empty_when_latest_pair_cannot_fit(tokenizer):
+    tokens, labels = tokenizer.encode_instruct_chat(
+        conversation=[
+            {'role': 'user', 'content': 'Question'},
+            {'role': 'assistant', 'content': 'Answer'},
+        ],
+        ignore_index=IGNORE_INDEX,
+        max_seq_len=1,
+        trim_to_context=True,
+    )
+
+    assert tokens == []
+    assert labels == []

--- a/tokenization/base.py
+++ b/tokenization/base.py
@@ -15,7 +15,7 @@ class PromptBuilder:
         self.ignore_index = ignore_index
         self.no_labels = no_labels
         self.system_prompt = tokenizer.system_prompt
-        self.eos_token = tokenizer.eos_token
+        self.eos_id = tokenizer.eos_id
         self.bos_id = tokenizer.bos_id
         self.tokens = []
         self.labels = []
@@ -37,13 +37,17 @@ class PromptBuilder:
             raise ValueError(f'Unknown role: {role}')
         return f'{self.ROLE_NAMES[role]}: '
 
-    def add_message(self, role, content, *, supervise=False, final_assistant=False):
+    def add_message(self, role, content, *, supervise=False, end_turn=False):
         prefix = self.role_prefix(role)
         self.push(self.encode(prefix), supervise=False)
 
         if role == 'assistant':
-            text = content + (self.eos_token if final_assistant else '\n')
-            self.push(self.encode(text), supervise=supervise)
+            self.push(self.encode(content), supervise=supervise)
+
+            if end_turn:
+                self.push([self.eos_id], supervise=supervise)
+            else:
+                self.push(self.encode('\n'), supervise=supervise)
         else:
             self.push(self.encode(content + '\n'), supervise=False)
 
@@ -90,9 +94,12 @@ class BaseTokenizer(ABC):
         builder = PromptBuilder(self, no_labels=True)
 
         for message in messages:
+            role = message['role']
+
             builder.add_message(
-                message['role'],
+                role,
                 message['content'],
+                end_turn=(role == "assistant")
             )
 
         builder.add_assistant_prefix()
@@ -115,31 +122,74 @@ class BaseTokenizer(ABC):
 
         return self.encode_instruct_messages_inference(messages)
 
+    def validate_conversation(
+        self,
+        conversation,
+        *,
+        expected_last_role,
+    ):
+        if not conversation:
+            raise ValueError('Conversation cannot be empty')
+
+        if conversation[-1]['role'] != expected_last_role:
+            raise ValueError(
+                f'Conversation must end with {expected_last_role}, '
+                f'got {conversation[-1]["role"]}'
+            )
+
+        expected_role = 'user'
+
+        for index, message in enumerate(conversation):
+            role = message['role']
+
+            if role not in {'user', 'assistant'}:
+                raise ValueError(
+                    f'Unexpected role at index {index}: {role}. '
+                    'System messages must be passed through system_prompt.'
+                )
+
+            if role != expected_role:
+                raise ValueError(
+                    f'Expected {expected_role} at index {index}, got {role}'
+                )
+
+            expected_role = (
+                'assistant'
+                if expected_role == 'user'
+                else 'user'
+            )
+
     def encode_instruct_chat(
         self,
         *,
         conversation,
         ignore_index: int,
+        system_prompt: str | None = None,
         max_seq_len: int | None = None,
         trim_to_context: bool = False
     ):
+        self.validate_conversation(conversation, expected_last_role='assistant')
+
+        system_prompt = (
+            self.system_prompt
+            if system_prompt is None
+            else system_prompt
+        )
+
         def encode_messages(messages):
             builder = PromptBuilder(self, ignore_index=ignore_index)
-            builder.add_message('system', self.system_prompt)
+            builder.add_message('system', system_prompt)
 
-            for idx, interaction in enumerate(messages):
+            for interaction in messages:
                 role = interaction['role']
                 content = interaction['content']
-
                 is_assistant = role == 'assistant'
-                is_last_message = idx == len(messages) - 1
-                is_final_assistant = is_assistant and is_last_message
 
                 builder.add_message(
                     role,
                     content,
-                    supervise=is_final_assistant,
-                    final_assistant=is_final_assistant
+                    supervise=is_assistant,
+                    end_turn=is_assistant
                 )
 
             return builder.build()
@@ -182,25 +232,38 @@ class BaseTokenizer(ABC):
         chosen: str,
         rejected: str,
         ignore_index: int,
+        system_prompt: str | None = None,
         max_seq_len: int | None = None,
         trim_to_context: bool = False
     ):
+        self.validate_conversation(conversation, expected_last_role='user')
+
+        system_prompt = (
+            self.system_prompt
+            if system_prompt is None
+            else system_prompt
+        )
+
         def encode_prompt(messages):
             prefix_builder = PromptBuilder(self, ignore_index=ignore_index)
-            prefix_builder.add_message('system', self.system_prompt)
+            prefix_builder.add_message('system', system_prompt)
 
             for interaction in messages:
+                role = interaction['role']
+
                 prefix_builder.add_message(
-                    interaction['role'],
+                    role,
                     interaction['content'],
                     supervise=False,
+                    end_turn=(role == 'assistant')
                 )
 
             prefix_builder.add_assistant_prefix()
 
             def build_answer(answer):
                 builder = prefix_builder.clone()
-                builder.push(builder.encode(answer + self.eos_token), supervise=True)
+                builder.push(builder.encode(answer), supervise=True)
+                builder.push([builder.eos_id], supervise=True)
                 return builder.build()
 
             prompt_ids, _ = prefix_builder.build()


### PR DESCRIPTION
The previous setup had two main problems: 
1 - We were replacing all system messages from the datasets with our custom system message. 
2 - In mult turn messages, only the last assistant message was being supervised.

The problem with 1 is that some datasets added instructions to the system problem, which can cause obvious problems for example if the system prompt says to fix grammar and the user just provides the input, then the output wouldn't be an obvious response that made sense and would confuse the model.
Problem with 2 is that that model has trouble learning the proper conversation flow and is likely to work better only on single turn conversations.

Changes:
- Source system prompts can override the default system prompt.
- Every SFT assistant is now supervised.
- Every completed assistant turn receives exactly one EOS token by ID.
- Historical assistant turns receive EOS in inference.
- DPO chosen and rejected responses end in a supervised EOS.
- Added tests to cover the most likely sources of issues.
- Updating models to use contiguous in the attn_mask.