### PR TITLE
baseline recipes for SFT

### DIFF
--- a/recipes/instruct/smollm2-360m/smollm2_360m_smoltalk_assistant_only_gg_template_h100.yaml
+++ b/recipes/instruct/smollm2-360m/smollm2_360m_smoltalk_assistant_only_gg_template_h100.yaml
@@ -1,0 +1,145 @@
+name: smollm2_360m_smoltalk_assistant_only_gg_template_h100
+description: >
+  SmolLM2-360M full SFT on Smol-SmolTalk, approximating the official
+  SmolLM2 recipe while using custom chat template, assistant only loss, and no sequence packing.
+
+config:
+  run:
+    name: smollm2_360m_smoltalk_assistant_only_gg_template_h100
+
+  runtime:
+    device_type: cuda
+    training_precision: bf16
+    use_torch_compile: true
+    use_fsdp: false
+    number_of_cpu_processes: 16
+
+  training:
+    stage: instruct
+    seed: 42
+    total_batch_size: 1277952
+    micro_batch_size: 2
+    max_steps: 5801
+    early_stopping_patience: 1000000
+    early_stopping_patience_skip_steps: 0
+
+  model:
+    architecture: hf_wrapper
+    hf_config:
+      model_name: HuggingFaceTB/SmolLM2-360M
+      random_init: false
+    max_seq_len: 8192
+
+  prompts:
+    system_prompt: "You are a helpful AI assistant named SmolLM"
+
+  tokenizer:
+    checkpoint_path: HuggingFaceTB/SmolLM2-360M
+    huggingface_tokenizer: true
+    prompt_format: gradient_garden
+    ignore_index: -100
+
+  paths:
+    datasets:
+      training_path: ./datasets/instruct_smollm2_smoltalk_8192
+    runs:
+      output_dir_path: ./runs
+
+  optimizers:
+    adamw:
+      max_lr: 1.0e-3
+      min_lr: 0.0
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+      schedulers:
+        active: cosine
+        cosine:
+          start_step: 0
+          warmup_steps: 580
+          max_steps: 5801
+    muon:
+      enabled: false
+
+  validation:
+    every_x_steps: 2901
+    validation_steps: 1143
+    run_on_first_step: true
+    run_on_last_step: true
+
+  generation:
+    every_x_steps: 2901
+    max_gen_len: 256
+    run_on_first_step: true
+    run_on_last_step: true
+
+  evals:
+    hellaswag:
+      every_x_steps: 2901
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    winogrande:
+      every_x_steps: 2901
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    arc_challenge:
+      every_x_steps: 2901
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    ifeval_no_external:
+      every_x_steps: 2901
+      max_gen_len: 256
+      number_of_examples: 100
+      run_on_first_step: true
+      run_on_last_step: true
+
+    custom_sft_smoke:
+      every_x_steps: 2901
+      max_gen_len: 256
+      number_of_examples: 100
+      run_on_first_step: true
+      run_on_last_step: true
+
+  checkpointing:
+    save_checkpoints: true
+    every_x_steps: 2901
+    max_number_checkpoints: 2
+    max_number_best_checkpoints: 1
+    run_on_first_step: false
+    run_on_last_step: true
+
+  wandb:
+    enabled: true
+
+data:
+  seed: 42
+
+  datasets_common_settings:
+    validation_ratio: 0.01
+    interleave_stopping_strategy: first_exhausted
+
+  datasets:
+    HuggingFaceTB/smol-smoltalk:
+      default:
+        weight: 1.0
+
+  evals:
+    hellaswag:
+      enabled: true
+
+    winogrande:
+      enabled: true
+
+    arc_challenge:
+      enabled: true
+
+    ifeval_no_external:
+      enabled: true
+
+    custom_sft_smoke:
+      enabled: true

--- a/recipes/instruct/smollm2-360m/smollm2_360m_smoltalk_assistant_only_gg_template_h100.yaml
+++ b/recipes/instruct/smollm2-360m/smollm2_360m_smoltalk_assistant_only_gg_template_h100.yaml
@@ -1,7 +1,8 @@
 name: smollm2_360m_smoltalk_assistant_only_gg_template_h100
 description: >
-  SmolLM2-360M full SFT on Smol-SmolTalk, approximating the official
-  SmolLM2 recipe while using custom chat template, assistant only loss, and no sequence packing.
+  SFT baseline for SmolLM2-360M on Smol-SmolTalk using the
+  Gradient Garden chat template and assistant only loss.
+  Does not include the official DPO stage as that will be a DPO recipe.
 
 config:
   run:
@@ -61,45 +62,45 @@ config:
       enabled: false
 
   validation:
-    every_x_steps: 2901
-    validation_steps: 1143
+    every_x_steps: 500
+    validation_steps: 2286
     run_on_first_step: true
     run_on_last_step: true
 
   generation:
-    every_x_steps: 2901
+    every_x_steps: 250
     max_gen_len: 256
     run_on_first_step: true
     run_on_last_step: true
 
   evals:
     hellaswag:
-      every_x_steps: 2901
+      every_x_steps: 1000
       number_of_examples: 200
       run_on_first_step: true
       run_on_last_step: true
 
     winogrande:
-      every_x_steps: 2901
+      every_x_steps: 1000
       number_of_examples: 200
       run_on_first_step: true
       run_on_last_step: true
 
     arc_challenge:
-      every_x_steps: 2901
+      every_x_steps: 1000
       number_of_examples: 200
       run_on_first_step: true
       run_on_last_step: true
 
     ifeval_no_external:
-      every_x_steps: 2901
+      every_x_steps: 1000
       max_gen_len: 256
       number_of_examples: 100
       run_on_first_step: true
       run_on_last_step: true
 
     custom_sft_smoke:
-      every_x_steps: 2901
+      every_x_steps: 1000
       max_gen_len: 256
       number_of_examples: 100
       run_on_first_step: true
@@ -107,8 +108,8 @@ config:
 
   checkpointing:
     save_checkpoints: true
-    every_x_steps: 2901
-    max_number_checkpoints: 2
+    every_x_steps: 500
+    max_number_checkpoints: 3
     max_number_best_checkpoints: 1
     run_on_first_step: false
     run_on_last_step: true

--- a/recipes/instruct/tendril/tendril_480m_smoltalk_assistant_only_gg_template_h100.yaml
+++ b/recipes/instruct/tendril/tendril_480m_smoltalk_assistant_only_gg_template_h100.yaml
@@ -1,6 +1,9 @@
 name: tendril_480m_smoltalk_assistant_only_gg_template_h100
 description: >
-  Tendril 480M full SFT on Smol-SmolTalk using custom chat template, assistant only loss, 2048 context window.
+  SFT conversational baseline for Tendril 480M on Smol-SmolTalk,
+  using the Gradient Garden chat template, assistant only loss, and a
+  2048 token context window. Requires a pretrained Tendril checkpoint
+  supplied through --checkpoint.
 
 config:
   run:

--- a/recipes/instruct/tendril/tendril_480m_smoltalk_assistant_only_gg_template_h100.yaml
+++ b/recipes/instruct/tendril/tendril_480m_smoltalk_assistant_only_gg_template_h100.yaml
@@ -1,0 +1,150 @@
+name: tendril_480m_smoltalk_assistant_only_gg_template_h100
+description: >
+  Tendril 480M full SFT on Smol-SmolTalk using custom chat template, assistant only loss, 2048 context window.
+
+config:
+  run:
+    name: tendril_480m_smoltalk_assistant_only_gg_template_h100
+
+  runtime:
+    device_type: cuda
+    training_precision: bf16
+    use_torch_compile: true
+    use_fsdp: false
+    number_of_cpu_processes: 16
+
+  training:
+    stage: instruct
+    seed: 42
+    total_batch_size: 319488
+    micro_batch_size: 2
+    max_steps: 5801
+    early_stopping_patience: 1000000
+    early_stopping_patience_skip_steps: 0
+
+  model:
+    architecture: tendril
+    dim: 1024
+    n_layers: 30
+    n_heads: 16
+    n_kv_heads: 8
+    multiple_of: 1024
+    ffn_dim_multiplier: 1.0
+    norm_eps: 1.0e-5
+    rope_theta: 500000.0
+    max_seq_len: 2048
+    tied_embeddings: true
+
+  prompts:
+    system_prompt: "You are Tendril, a helpful AI assistant."
+
+  tokenizer:
+    checkpoint_path: HuggingFaceTB/SmolLM2-360M
+    huggingface_tokenizer: true
+    prompt_format: gradient_garden
+    ignore_index: -100
+
+  paths:
+    datasets:
+      training_path: ./datasets/instruct_smollm2_smoltalk_2048_tendril
+    runs:
+      output_dir_path: ./runs
+
+  optimizers:
+    adamw:
+      max_lr: 1.0e-3
+      min_lr: 0.0
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+      schedulers:
+        active: cosine
+        cosine:
+          start_step: 0
+          warmup_steps: 580
+          max_steps: 5801
+    muon:
+      enabled: false
+
+  validation:
+    every_x_steps: 500
+    validation_steps: 2286
+    run_on_first_step: true
+    run_on_last_step: true
+
+  generation:
+    every_x_steps: 250
+    max_gen_len: 256
+    run_on_first_step: true
+    run_on_last_step: true
+
+  evals:
+    hellaswag:
+      every_x_steps: 1000
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    winogrande:
+      every_x_steps: 1000
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    arc_challenge:
+      every_x_steps: 1000
+      number_of_examples: 200
+      run_on_first_step: true
+      run_on_last_step: true
+
+    ifeval_no_external:
+      every_x_steps: 1000
+      max_gen_len: 256
+      number_of_examples: 100
+      run_on_first_step: true
+      run_on_last_step: true
+
+    custom_sft_smoke:
+      every_x_steps: 1000
+      max_gen_len: 256
+      number_of_examples: 100
+      run_on_first_step: true
+      run_on_last_step: true
+
+  checkpointing:
+    save_checkpoints: true
+    every_x_steps: 500
+    max_number_checkpoints: 3
+    max_number_best_checkpoints: 1
+    run_on_first_step: false
+    run_on_last_step: true
+
+  wandb:
+    enabled: true
+
+data:
+  seed: 42
+
+  datasets_common_settings:
+    validation_ratio: 0.01
+    interleave_stopping_strategy: first_exhausted
+
+  datasets:
+    HuggingFaceTB/smol-smoltalk:
+      default:
+        weight: 1.0
+
+  evals:
+    hellaswag:
+      enabled: true
+
+    winogrande:
+      enabled: true
+
+    arc_challenge:
+      enabled: true
+
+    ifeval_no_external:
+      enabled: true
+
+    custom_sft_smoke:
+      enabled: true


### PR DESCRIPTION
Adds two baseline recipes for SFT:
- Tendril recipe which expect to start the training from an existing checkpoint via `--checkpoint` flag;
- Smoll recipe, which loads the pretraining weights directly from HF for the respective config (Smoll360m in this case);

NOTE: These are experimental and will likely need adjustments but can serve as a guide / demo to produce a very simple conversational chat bot. 