### PR TITLE
Adding extra source metadata to dataset prep state (pretraining)

### DIFF
--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -384,13 +384,16 @@ def shard_and_tokenize(
         train_buffer = np.load(train_buffer_path)
         val_buffer = np.load(val_buffer_path)
 
+        saved_source_metadata = state_data['source_metadata']
+        assert saved_source_metadata == state.source_metadata, 'Source metadata in preparation state does not match the source metadata from the current recipe.'
+
         state.status = state_data['status']
         state.docs_seen = state_data['docs_seen']
         state.source_doc_counts = state_data['source_doc_counts']
         state.source_token_counts = state_data['source_token_counts']
         state.split_doc_counts = state_data['split_doc_counts']
         state.split_token_counts = state_data['split_token_counts']
-        state.source_metadata = state_data['source_metadata']
+        state.source_metadata = saved_source_metadata
         state.train_writer.load_state_dict(state_data['train_writer_state'])
         state.train_writer.load_buffer_checkpoint(train_buffer)
         state.val_writer.load_state_dict(state_data['val_writer_state'])

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -308,7 +308,8 @@ def shard_and_tokenize(
     target_tokens,
     validation_ratio,
     num_proc,
-    chunksize
+    chunksize,
+    source_metadata=None
 ):
     root_path = Path(train_path).parent
     state_dir = root_path / '.prep_state'
@@ -328,6 +329,7 @@ def shard_and_tokenize(
         source_token_counts: dict
         split_doc_counts: dict
         split_token_counts: dict
+        source_metadata: dict
 
     def save_state(state: ShardAndTokenizeState):
         state_data = {
@@ -337,6 +339,7 @@ def shard_and_tokenize(
             'source_token_counts': state.source_token_counts,
             'split_doc_counts': state.split_doc_counts,
             'split_token_counts': state.split_token_counts,
+            'source_metadata': state.source_metadata,
             'train_writer_state': state.train_writer.get_state_dict(),
             'train_writer_buffer_file_path': str(train_buffer_path),
             'val_writer_state': state.val_writer.get_state_dict(),
@@ -350,7 +353,7 @@ def shard_and_tokenize(
         try:
             np.save(temp_train_buffer_path, state.train_writer.get_buffer_checkpoint())
             np.save(temp_val_buffer_path, state.val_writer.get_buffer_checkpoint())
-            save_json_file(temp_state_path, state_data)
+            save_json_file(temp_state_path, state_data, indent=2)
 
             temp_train_buffer_path.replace(train_buffer_path)
             temp_val_buffer_path.replace(val_buffer_path)
@@ -387,6 +390,7 @@ def shard_and_tokenize(
         state.source_token_counts = state_data['source_token_counts']
         state.split_doc_counts = state_data['split_doc_counts']
         state.split_token_counts = state_data['split_token_counts']
+        state.source_metadata = state_data['source_metadata']
         state.train_writer.load_state_dict(state_data['train_writer_state'])
         state.train_writer.load_buffer_checkpoint(train_buffer)
         state.val_writer.load_state_dict(state_data['val_writer_state'])
@@ -448,7 +452,8 @@ def shard_and_tokenize(
         source_doc_counts={},
         source_token_counts={},
         split_doc_counts={ 'train': 0, 'val': 0 },
-        split_token_counts={ 'train': 0, 'val': 0 }
+        split_token_counts={ 'train': 0, 'val': 0 },
+        source_metadata=source_metadata or {}
     )
     state, loaded = load_state(state)
     if state.status == 'completed':

--- a/datasets_preparation/data_preparation_utils.py
+++ b/datasets_preparation/data_preparation_utils.py
@@ -385,7 +385,8 @@ def shard_and_tokenize(
         val_buffer = np.load(val_buffer_path)
 
         saved_source_metadata = state_data['source_metadata']
-        assert saved_source_metadata == state.source_metadata, 'Source metadata in preparation state does not match the source metadata from the current recipe.'
+        if saved_source_metadata != state.source_metadata:
+            raise ValueError('Source metadata in preparation state does not match the source metadata from the current recipe.')
 
         state.status = state_data['status']
         state.docs_seen = state_data['docs_seen']

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -125,7 +125,7 @@ def download_and_prepare_data(
             'start_document': start_document
         }
 
-        logger.info(f'Using {source_key} at revision {revision}')
+        logger.info(f'Using {source_key} at revision {resolved_revision}')
 
         ds = load_dataset(
             ds_id,

--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -8,6 +8,7 @@ from datasets import (
     load_dataset,
     interleave_datasets
 )
+from huggingface_hub import HfApi
 from datasets_preparation.data_preparation_utils import (
     make_source_key,
     assert_common_structure_and_extract,
@@ -93,6 +94,7 @@ def download_and_prepare_data(
     interleave_stopping_strategy
 ):
     prepared_datasets = []
+    source_metadata = {}
     for dataset in valid_datasets:
         ds_id = dataset['id']
         name = dataset.get('name', None)
@@ -107,16 +109,30 @@ def download_and_prepare_data(
         if start_document < 0:
             raise ValueError(f'start_document must be >= 0 for {ds_id}/{name}')
 
+        revision = transforms.get('revision', 'main')
+        resolved_revision = HfApi(token=config.third_party.hf_token).dataset_info(ds_id, revision=revision).sha
+
         max_datapoints = transforms.get('max_datapoints', None)
 
         hf_name = None if name == 'default' else name
         source_key = make_source_key(ds_id, name)
+
+        source_metadata[source_key] = {
+            'dataset_id': ds_id,
+            'name': name,
+            'split': split,
+            'revision': resolved_revision,
+            'start_document': start_document
+        }
+
+        logger.info(f'Using {source_key} at revision {revision}')
 
         ds = load_dataset(
             ds_id,
             name=hf_name,
             split=split,
             streaming=True,
+            revision=resolved_revision,
             token=config.third_party.hf_token
         )
 
@@ -168,7 +184,7 @@ def download_and_prepare_data(
     else:
         prepared_dataset = prepared_datasets[0]
 
-    return prepared_dataset
+    return prepared_dataset, source_metadata
 
 tokenizer = None
 def tokenize(tokenizer_kwargs, doc):
@@ -209,7 +225,7 @@ def prepare_pretraining_dataset(
     if not 0.0 < validation_ratio < 1.0:
         raise ValueError('"validation_ratio" must be > 0 and < 1')
 
-    prepared_dataset = download_and_prepare_data(
+    prepared_dataset, source_metadata = download_and_prepare_data(
         config=config,
         seed=seed,
         valid_datasets=valid_datasets,
@@ -236,5 +252,6 @@ def prepare_pretraining_dataset(
         target_tokens=target_tokens,
         validation_ratio=validation_ratio,
         num_proc=num_proc,
-        chunksize=config.data_preparation.mp_pool_chunk_size
+        chunksize=config.data_preparation.mp_pool_chunk_size,
+        source_metadata=source_metadata
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic
 pydantic-settings
 torch
 datasets
+huggingface_hub
 transformers
 wandb
 gradio

--- a/utils.py
+++ b/utils.py
@@ -55,11 +55,11 @@ def load_json_file(file_path):
     with open(file_path, 'r', encoding='utf-8') as file:
         return json.load(file)
 
-def save_json_file(file_path, data):
+def save_json_file(file_path, data, indent=None):
     file_path = Path(file_path)
     file_path.parent.mkdir(parents=True, exist_ok=True)
     with open(file_path, 'w', encoding='utf-8') as file:
-        json.dump(data, file, ensure_ascii=False)
+        json.dump(data, file, ensure_ascii=False, indent=indent)
 
 def save_jsonl_file(file_path, items):
     with open(file_path, 'w', encoding='utf-8') as file:


### PR DESCRIPTION
Relates to #104 

This PR adds extra metadata to the state file created when preparing a pretraining dataset:
- dataset_id     
- name
- split
- revision
- start_document