### PR TITLE
Refactoring + support DatasetSourceWrapper and DatasetWrapper

### DIFF
--- a/datasets_preparation/prepare_pretraining_dataset.py
+++ b/datasets_preparation/prepare_pretraining_dataset.py
@@ -4,17 +4,14 @@ import time
 import copy
 
 from tokenization.tokenizer import init_tokenizer
-from datasets import (
-    load_dataset,
-    interleave_datasets
-)
+from datasets import interleave_datasets
 from huggingface_hub import HfApi
 from datasets_preparation.utils.common import (
     make_source_key,
     assert_common_structure_and_extract
 )
 from datasets_preparation.utils.shard_writer import shard_and_tokenize
-from datasets_preparation.utils.parquet_search import load_dataset_with_search_parquet
+from datasets_preparation.utils.dataset_wrapper import DatasetSourceWrapper
 from datasets_preparation.default_mixes import DEFAULT_PRETRAINING_MIX
 from logger import logger
 
@@ -96,10 +93,11 @@ def download_and_prepare_data(
     num_proc
 ):
     prepared_datasets = []
-    source_metadata = {}
     for dataset in valid_datasets:
         ds_id = dataset['id']
         name = dataset.get('name', None)
+
+        source_key = make_source_key(ds_id, name)
 
         dataset_config = SUPPORTED_HF_DATASETS[ds_id][name]
         split = dataset_config['split']
@@ -107,63 +105,32 @@ def download_and_prepare_data(
 
         transforms = dataset.get('transforms', {})
 
+        revision = transforms.get('revision', 'main')
+        max_datapoints = transforms.get('max_datapoints', None)
+        search_parquet = transforms.get('search_parquet', False)
+
         start_document = int(transforms.get('start_document', 0))
         if start_document < 0:
             raise ValueError(f'start_document must be >= 0 for {ds_id}/{name}')
 
-        revision = transforms.get('revision', 'main')
         resolved_revision = HfApi(token=config.third_party.hf_token).dataset_info(ds_id, revision=revision).sha
-
-        max_datapoints = transforms.get('max_datapoints', None)
-
-        hf_name = None if name == 'default' else name
-        source_key = make_source_key(ds_id, name)
-
-        search_parquet = transforms.get('search_parquet', False)
-
-        source_metadata[source_key] = {
-            'dataset_id': ds_id,
-            'name': name,
-            'split': split,
-            'revision': resolved_revision,
-            'start_document': start_document,
-            'search_parquet': search_parquet
-        }
-
         logger.info(f'Using {source_key} at revision {resolved_revision}')
 
         if search_parquet is True:
             logger.info(f'The "search_parquet" flag is set. Using parquet loader...')
 
-            ds = load_dataset_with_search_parquet(
-                ds_id=ds_id,
-                split=split,
-                streaming=True,
-                revision=resolved_revision,
-                start_document=start_document,
-                token=config.third_party.hf_token,
-                num_proc=num_proc
-            )
-        else:
-            ds = load_dataset(
-                ds_id,
-                name=hf_name,
-                split=split,
-                streaming=True,
-                revision=resolved_revision,
-                token=config.third_party.hf_token
-            )
-
-            if start_document > 0:
-                logger.info(f'Skipping {start_document:,} documents for {source_key}')
-                ds = ds.skip(start_document)
-
-        columns_to_remove = ds.column_names
-
-        if max_datapoints is not None:
-            max_datapoints = int(max_datapoints)
-            assert max_datapoints > 0
-            ds = ds.take(max_datapoints)
+        ds_source = DatasetSourceWrapper(
+            ds_id=ds_id,
+            name=name,
+            source_key=source_key,
+            split=split,
+            resolved_revision=resolved_revision,
+            start_document=start_document,
+            token=config.third_party.hf_token,
+            max_datapoints=max_datapoints,
+            search_parquet=search_parquet,
+            num_proc=num_proc
+        )
 
         def normalize(
             batch,
@@ -180,19 +147,19 @@ def download_and_prepare_data(
                 'source': [source_key] * len(texts)
             }
 
-        ds = ds.map(
+        ds_source = ds_source.map(
             normalize,
             batched=True,
             batch_size=config.data_preparation.hf_map_batch_size,
-            remove_columns=columns_to_remove
+            remove_columns=ds_source.column_names
         )
 
-        prepared_datasets.append(ds)
+        prepared_datasets.append(ds_source)
 
     if len(prepared_datasets) > 1:
         logger.info(f'Preparing Interleaving iterator... This operation can take a few minutes... Using strategy: {interleave_stopping_strategy}')
         prepared_dataset = interleave_datasets(
-            prepared_datasets,
+            [source.dataset for source in prepared_datasets],
             probabilities=probabilities,
             seed=seed,
             stopping_strategy=interleave_stopping_strategy
@@ -202,7 +169,7 @@ def download_and_prepare_data(
     else:
         prepared_dataset = prepared_datasets[0]
 
-    return prepared_dataset, source_metadata
+    return prepared_dataset
 
 tokenizer = None
 def tokenize(tokenizer_kwargs, doc):
@@ -243,7 +210,7 @@ def prepare_pretraining_dataset(
     if not 0.0 < validation_ratio < 1.0:
         raise ValueError('"validation_ratio" must be > 0 and < 1')
 
-    prepared_dataset, source_metadata = download_and_prepare_data(
+    prepared_dataset = download_and_prepare_data(
         config=config,
         seed=seed,
         valid_datasets=valid_datasets,
@@ -271,6 +238,5 @@ def prepare_pretraining_dataset(
         target_tokens=target_tokens,
         validation_ratio=validation_ratio,
         num_proc=num_proc,
-        chunksize=config.data_preparation.mp_pool_chunk_size,
-        source_metadata=source_metadata
+        chunksize=config.data_preparation.mp_pool_chunk_size
     )

--- a/datasets_preparation/utils/dataset_wrapper.py
+++ b/datasets_preparation/utils/dataset_wrapper.py
@@ -1,8 +1,67 @@
-class PretrainingSource:
-    def __init__(self, *, dataset, source_key, documents_seen=0):
-        self.dataset = dataset
+from datasets import load_dataset
+from datasets_preparation.utils.parquet_search import load_dataset_with_search_parquet
+
+
+class DatasetSourceWrapper:
+    def __init__(
+        self,
+        *,
+        ds_id,
+        name,
+        source_key,
+        split,
+        resolved_revision,
+        start_document,
+        token,
+        max_datapoints=None,
+        search_parquet=False,
+        num_proc=None,
+    ):
         self.source_key = source_key
-        self.documents_seen = documents_seen
+        self.documents_seen = start_document
+
+        self.metadata = {
+            'dataset_id': ds_id,
+            'name': name,
+            'split': split,
+            'revision': resolved_revision,
+            'start_document': start_document,
+            'search_parquet': search_parquet
+        }
+
+        hf_name = None if name == 'default' else name
+
+        if search_parquet is True:
+            self.dataset = load_dataset_with_search_parquet(
+                ds_id=ds_id,
+                split=split,
+                streaming=True,
+                revision=resolved_revision,
+                start_document=start_document,
+                token=token,
+                num_proc=num_proc
+            )
+        else:
+            self.dataset = load_dataset(
+                ds_id,
+                name=hf_name,
+                split=split,
+                streaming=True,
+                revision=resolved_revision,
+                token=token
+            )
+
+            if start_document > 0:
+                logger.info(f'Skipping {start_document:,} documents for {source_key}')
+                ds = ds.skip(start_document)
+
+        if max_datapoints is not None:
+            max_datapoints = int(max_datapoints)
+            assert max_datapoints > 0
+            self.dataset = self.dataset.take(max_datapoints)
+
+    def metadata(self):
+        return self.metadata
 
     def __iter__(self):
         yield from self.dataset
@@ -25,5 +84,23 @@ class PretrainingSource:
             raise ValueError('documents_seen must be >= 0')
         self.documents_seen = state['documents_seen']
 
-class PretrainingDataset:
-    pass
+    @property
+    def column_names(self):
+        return self.dataset.column_names
+
+    def map(self, *args, **kwargs):
+        self.dataset = self.dataset.map(*args, **kwargs)
+        return self
+
+class DatasetWrapper:
+    def __init__(self, sources: list[DatasetSourceWrapper]):
+        self.sources = sources
+
+    def __iter__(self):
+        yield from self.sources
+
+    def commit(self):
+        pass
+
+    def state_dict(self):
+        pass

--- a/datasets_preparation/utils/dataset_wrapper.py
+++ b/datasets_preparation/utils/dataset_wrapper.py
@@ -1,5 +1,6 @@
 from datasets import load_dataset
 from datasets_preparation.utils.parquet_search import load_dataset_with_search_parquet
+from logger import logger
 
 
 class DatasetSourceWrapper:
@@ -53,7 +54,7 @@ class DatasetSourceWrapper:
 
             if start_document > 0:
                 logger.info(f'Skipping {start_document:,} documents for {source_key}')
-                ds = ds.skip(start_document)
+                self.dataset = self.dataset.skip(start_document)
 
         if max_datapoints is not None:
             max_datapoints = int(max_datapoints)

--- a/datasets_preparation/utils/dataset_wrapper.py
+++ b/datasets_preparation/utils/dataset_wrapper.py
@@ -16,19 +16,18 @@ class DatasetSourceWrapper:
         token,
         max_datapoints=None,
         search_parquet=False,
-        num_proc=None,
+        num_proc=None
     ):
+        self.ds_id = ds_id
+        self.name = name
         self.source_key = source_key
-        self.documents_seen = start_document
+        self.split = split
+        self.resolved_revision = resolved_revision
+        self.start_document = start_document
+        self.max_datapoints = max_datapoints
+        self.search_parquet = search_parquet
 
-        self.metadata = {
-            'dataset_id': ds_id,
-            'name': name,
-            'split': split,
-            'revision': resolved_revision,
-            'start_document': start_document,
-            'search_parquet': search_parquet
-        }
+        self.documents_seen = 0
 
         hf_name = None if name == 'default' else name
 
@@ -61,8 +60,16 @@ class DatasetSourceWrapper:
             assert max_datapoints > 0
             self.dataset = self.dataset.take(max_datapoints)
 
+    @property
     def metadata(self):
-        return self.metadata
+        return {
+            'dataset_id': self.ds_id,
+            'name': self.name,
+            'split': self.split,
+            'revision': self.resolved_revision,
+            'start_document': self.start_document,
+            'search_parquet': self.search_parquet
+        }
 
     def __iter__(self):
         yield from self.dataset

--- a/datasets_preparation/utils/shard_writer.py
+++ b/datasets_preparation/utils/shard_writer.py
@@ -226,8 +226,7 @@ def shard_and_tokenize(
     target_tokens,
     validation_ratio,
     num_proc,
-    chunksize,
-    source_metadata=None
+    chunksize
 ):
     root_path = Path(train_path).parent
     state_dir = root_path / '.prep_state'
@@ -365,6 +364,9 @@ def shard_and_tokenize(
         return train_writer.is_done() and val_writer.is_done()
 
     checkpoint_interval_docs = max(1, num_proc * chunksize) # save every time all workers complete.
+
+    # TODO extract from the future dataset wrapper
+    source_metadata = {}
 
     state = ShardAndTokenizeState(
         train_writer=train_writer,


### PR DESCRIPTION
Relates to #104 

This PR focus on the rework for the dataset abstraction and custom interleave strategy.
Changes include:
- Rework to support custom types (DatasetSourceWrapper and DatasetWrapper) that are needed later for the custom interleave mechanism that will be introduced in a new PR.

NOTE: As part of this PR, we intentionally disabled multi source resume. Will be fixed in the next PR.